### PR TITLE
Directly decode `orjson.dumps` output

### DIFF
--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -135,9 +135,8 @@ def set_logging_config(module_name, timestamper):
             "plain": {
                 "()": structlog.stdlib.ProcessorFormatter,
                 "processor": structlog.processors.JSONRenderer(
-                    serializer=lambda *args, **kwargs: str(
-                        orjson.dumps(*args, **kwargs),
-                        "utf-8",
+                    serializer=lambda *args, **kwargs: (
+                        orjson.dumps(*args, **kwargs).decode()
                     ),
                     option=orjson.OPT_SORT_KEYS,
                 ),


### PR DESCRIPTION
As opposed to manually converting output into string format.

See: [Pydantic: Exporting models - Custom JSON (de)serialisation](https://pydantic-docs.helpmanual.io/usage/exporting_models/#custom-json-deserialisation)