### PR TITLE
👷‍♀️ Extract Discrete Dependency vs. Project Installation Commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          make provision-environment
+          make install-dependencies
 
       - name: Install Go for pre-commit hook (shfmt)
         run: |
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          make provision-environment
+          make install-dependencies
 
       - name: Run dependency security vulnerability analysis
         run: |
@@ -150,7 +150,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           command: |
-            make provision-environment
+            make install-dependencies
 
       - name: Run tox targets for ${{ matrix.python-version }}
         uses: nick-invision/retry@v2
@@ -208,7 +208,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           command: |
-            make provision-environment
+            make install-dependencies
 
       - name: Run benchmarks for ${{ matrix.python-version }}
         id: performance-testing
@@ -255,7 +255,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          make provision-environment
+          make install-dependencies
 
       - name: Run mutation testing
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           make install-dependencies
 
+      - name: Install project
+        run: |
+          make install-project
+
       - name: Build Documentation
         run: |
           make docs-html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          make provision-environment
+          make install-dependencies
 
       - name: Build Documentation
         run: |

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -52,7 +52,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           command: |
-            make provision-environment
+            make install-dependencies
 
       - name: Run benchmarks for ${{ matrix.python-version }}
         id: performance-testing

--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,12 @@ endif
 .PHONY: install-dependencies
 ## Install Python dependencies specified in `poetry.lock`
 install-dependencies:
-	poetry install --no-interaction --no-root --extras docs
+	poetry install --no-interaction --no-root --extras docs -vv
 
 .PHONY: install-project
 ## Install structlog-sentry-logger source code (in editable mode)
 install-project:
-	poetry install --no-interaction
+	poetry install --no-interaction -vv
 	$(MAKE) clean
 
 .PHONY: generate-requirements

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ package:
 
 .PHONY: tox-%
 ## Run specified tox testenvs
-tox-%: update-dependencies generate-requirements
+tox-%: generate-requirements
 	poetry run tox -e $* -- $(POSARGS)
 	$(MAKE) clean-requirements
 
@@ -156,7 +156,7 @@ tox-%: update-dependencies generate-requirements
 ifeq (${CI}, true)
 test: export TOX_PARALLEL_NO_SPINNER=1
 endif
-test: update-dependencies generate-requirements
+test: generate-requirements
 	poetry run tox --parallel
 	$(MAKE) clean-requirements
 

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,24 @@ else
 endif
 
 .PHONY: update-dependencies
-## Install Python dependencies,
-## updating packages in `poetry.lock` with any newer versions specified in
-## `pyproject.toml`, and install structlog-sentry-logger source code
+## Update and install Python dependencies,
+## updating packages in `poetry.lock` with any newer versions
+## that adhere to `pyproject.toml` version range constraints
 update-dependencies:
 	poetry update --lock
 ifneq (${CI}, true)
-	poetry install --extras docs
+	$(MAKE) install-dependencies
 endif
+
+.PHONY: install-dependencies
+## Install Python dependencies specified in `poetry.lock`
+install-dependencies:
+	poetry install --no-interaction --no-root --extras docs
+
+.PHONY: install-project
+## Install structlog-sentry-logger source code (in editable mode)
+install-project:
+	poetry install --no-interaction
 	$(MAKE) clean
 
 .PHONY: generate-requirements

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,7 @@ clean:
 
 .PHONY: provision-environment
 ## Set up Python virtual environment with installed project dependencies
-provision-environment: _validate_poetry_installation
-	poetry update --lock -vv
-	poetry install --extras docs -vv
+provision-environment: _validate_poetry_installation install-dependencies install-project
 
 .PHONY: install-pre-commit-hooks
 ## Install git pre-commit hooks locally


### PR DESCRIPTION
Separating dependency updates from dependency/project installations allows callers to perform only the required operations needed for their specific task. Not only does this result in faster iteration cycles and fewer bugs, it also better communicates what is actually happening in dependent workflows.