### PR TITLE
👷‍♀️ Elide Unused Dependencies Installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ jobs:
           poetry config virtualenvs.in-project true
           poetry config --list
 
-      - name: Install dependencies
+      - name: Install Tox
         run: |
-          make install-dependencies
+          pip install --constraint=.github/workflows/constraints.txt tox
+          tox --version
 
       - name: Install Go for pre-commit hook (shfmt)
         run: |
@@ -84,9 +85,10 @@ jobs:
           poetry config virtualenvs.in-project true
           poetry config --list
 
-      - name: Install dependencies
+      - name: Install Tox
         run: |
-          make install-dependencies
+          pip install --constraint=.github/workflows/constraints.txt tox
+          tox --version
 
       - name: Run dependency security vulnerability analysis
         run: |
@@ -144,13 +146,14 @@ jobs:
           poetry config virtualenvs.in-project true
           poetry config --list
 
-      - name: Install dependencies
+      - name: Install Tox
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: |
-            make install-dependencies
+            pip install --constraint=.github/workflows/constraints.txt tox
+            tox --version
 
       - name: Run tox targets for ${{ matrix.python-version }}
         uses: nick-invision/retry@v2
@@ -202,13 +205,14 @@ jobs:
           poetry config virtualenvs.in-project true
           poetry config --list
 
-      - name: Install dependencies
+      - name: Install Tox
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: |
-            make install-dependencies
+            pip install --constraint=.github/workflows/constraints.txt tox
+            tox --version
 
       - name: Run benchmarks for ${{ matrix.python-version }}
         id: performance-testing
@@ -253,9 +257,10 @@ jobs:
           poetry config virtualenvs.in-project true
           poetry config --list
 
-      - name: Install dependencies
+      - name: Install Tox
         run: |
-          make install-dependencies
+          pip install --constraint=.github/workflows/constraints.txt tox
+          tox --version
 
       - name: Run mutation testing
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,15 +147,11 @@ jobs:
           poetry config --list
 
       - name: Install Tox & Tox GH Actions Plugin
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          # yamllint disable rule:line-length
-          command: |
-            pip install --constraint=.github/workflows/constraints.txt tox tox-gh-actions
-            tox --version
-          # yamllint enable rule:line-length
+        # yamllint disable rule:line-length
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt tox tox-gh-actions
+          tox --version
+        # yamllint enable rule:line-length
 
       - name: Run tox targets for ${{ matrix.python-version }}
         uses: nick-invision/retry@v2
@@ -208,13 +204,9 @@ jobs:
           poetry config --list
 
       - name: Install Tox
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |
-            pip install --constraint=.github/workflows/constraints.txt tox
-            tox --version
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt tox
+          tox --version
 
       - name: Run benchmarks for ${{ matrix.python-version }}
         id: performance-testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,16 @@ jobs:
           poetry config virtualenvs.in-project true
           poetry config --list
 
-      - name: Install Tox
+      - name: Install Tox & Tox GH Actions Plugin
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 3
+          # yamllint disable rule:line-length
           command: |
-            pip install --constraint=.github/workflows/constraints.txt tox
+            pip install --constraint=.github/workflows/constraints.txt tox tox-gh-actions
             tox --version
+          # yamllint enable rule:line-length
 
       - name: Run tox targets for ${{ matrix.python-version }}
         uses: nick-invision/retry@v2

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,3 +1,4 @@
 pip==21.2.4
 poetry==1.1.9
 tox==3.24.4
+tox-gh-actions==2.7.0

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -47,13 +47,9 @@ jobs:
           poetry config --list
 
       - name: Install Tox
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |
-            pip install --constraint=.github/workflows/constraints.txt tox
-            tox --version
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt tox
+          tox --version
 
       - name: Run benchmarks for ${{ matrix.python-version }}
         id: performance-testing

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -46,13 +46,14 @@ jobs:
           poetry config virtualenvs.in-project true
           poetry config --list
 
-      - name: Install dependencies
+      - name: Install Tox
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: |
-            make install-dependencies
+            pip install --constraint=.github/workflows/constraints.txt tox
+            tox --version
 
       - name: Run benchmarks for ${{ matrix.python-version }}
         id: performance-testing


### PR DESCRIPTION
Most workflows run in isolated tox test environments which manage their own required dependencies. Because of this, and because Poetry is used as the project's package and dependency management tool, `poetry` and `tox` are the only required dependencies for these workflows (with the exception of unit testing which also requires `tox-gh-actions`). 

Restricting dependency installations to only the aforementioned will result in faster iteration cycles and fewer bugs, it also better communicates what is actually happening in CI workflows.