### PR TITLE
👷‍♀️ Namespace CI Jobs Caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           path: |
             .tox
           # yamllint disable-line rule:line-length
-          key: tox-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: tox-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install Go for pre-commit hook (shfmt)
         run: |
@@ -107,7 +107,7 @@ jobs:
           path: |
             .tox
           # yamllint disable-line rule:line-length
-          key: tox-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: tox-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Run dependency security vulnerability analysis
         run: |
@@ -179,7 +179,7 @@ jobs:
           path: |
             .tox
           # yamllint disable-line rule:line-length
-          key: tox-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: tox-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Run tox targets for ${{ matrix.python-version }}
         uses: nick-invision/retry@v2
@@ -292,7 +292,7 @@ jobs:
           path: |
             .tox
           # yamllint disable-line rule:line-length
-          key: tox-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: tox-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Run mutation testing
         run: |

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -58,7 +58,7 @@ jobs:
           path: |
             .tox
           # yamllint disable-line rule:line-length
-          key: tox-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: tox-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Run benchmarks for ${{ matrix.python-version }}
         id: performance-testing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           path: |
             .tox
           # yamllint disable-line rule:line-length
-          key: tox-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: tox-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       # Update the project version number to the dev version that was
       # generated upstream (only used in non-release builds; else project


### PR DESCRIPTION
Reduces the size of each cache and ensures cache hits occur if and only if jobs had previously succeeded (thus implying that job-specific testenvs had been correctly provisioned in `.tox`).