### PR TITLE
💥  Write Local Log Files as JSON Lines Format

### DIFF
--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -182,7 +182,7 @@ def get_handlers(module_name: str) -> dict:
         base_handlers[default_key]["formatter"] = "colored"
         # Add filename handler
         file_timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%d")
-        log_file_name = f"{file_timestamp}_{module_name}.json"
+        log_file_name = f"{file_timestamp}_{module_name}.jsonl"
         log_file_path = LOG_DATA_DIR / log_file_name
         base_handlers["filename"] = {
             "level": "DEBUG",


### PR DESCRIPTION
Since logs lines are not comma-delimited, they have in actuality been JSON Lines files this entire time (i.e., they have not been valid JSON files).

See: [JSON Lines](https://jsonlines.org/)