### PR TITLE
⚡  Elide Log Processing for Logs Under the Global Log Level Threshold

### DIFF
--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -212,6 +212,7 @@ def set_structlog_config(timestamper: structlog.processors.TimeStamper) -> None:
         add_severity_field_from_level_if_in_cloud_environment,
     ]
     stdlib_log_compatibility_processors = [
+        structlog.stdlib.filter_by_level,
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.PositionalArgumentsFormatter(),


### PR DESCRIPTION
See: https://www.structlog.org/en/stable/standard-library.html#processors