### PR TITLE
✨  Add Seconds to Log File Timestamp Suffix

### DIFF
--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -187,7 +187,7 @@ def get_handlers(module_name: str) -> dict:
         # Prettify stdout/stderr streams
         base_handlers[default_key]["formatter"] = "colored"
         # Add filename handler
-        file_timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+        file_timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%d-%s")
         log_file_name = f"{file_timestamp}_{module_name}.jsonl"
         log_file_path = LOG_DATA_DIR / log_file_name
         base_handlers["filename"] = {


### PR DESCRIPTION
Improve precision to better distinguish logs from distinct program execution (i.e., those that occur on the same day).