### PR TITLE
⚡  Make Cloud Logging mode a logger configuration-time option

### DIFF
--- a/.mutmut-cache
+++ b/.mutmut-cache
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:79c9db6fd92ac1fff97b6402447a5998bf01e87d17688809e5f06e235ba99166
-size 122880
+oid sha256:333dbabcb7ed545ba1a93014f80cbe1c0f679b6f39479cc8d760eae2027fbb65
+size 126976


### PR DESCRIPTION
SSIA

~1.19x to ~1.23x performance improvement.

Before:
```
---------------------------------------------------------------------------------------------------------------------------------------- benchmark: 14 tests ----------------------------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                                                  Min                    Max                   Mean                StdDev                 Median                   IQR            Outliers         OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_gold_standard_structlog_non_str_keys                                                                     751.0000 (1.0)       1,482.0000 (1.0)         851.4327 (1.0)         57.8952 (1.0)         843.0000 (1.0)         28.0000 (1.0)       210;216  1,174.4909 (1.0)        1315           1
test_gold_standard_structlog                                                                                  862.0000 (1.15)      2,798.0000 (1.89)        992.8936 (1.17)       104.5924 (1.81)        970.0000 (1.15)        51.0000 (1.82)       92;114  1,007.1573 (0.86)       1165           1
test_orjson_serializer_non_str_keys[structlog-specific config (Optimized)-Sentry integration disabled]      1,627.0000 (2.17)      3,296.0000 (2.22)      1,879.2910 (2.21)       204.9706 (3.54)      1,827.0000 (2.17)        73.0000 (2.61)        57;79    532.1156 (0.45)        622           1
test_orjson_serializer[structlog-specific config (Optimized)-Sentry integration disabled]                   1,894.0000 (2.52)      2,473.0000 (1.67)      1,989.5026 (2.34)        72.1945 (1.25)      1,966.0000 (2.33)        52.7500 (1.88)        58;46    502.6382 (0.43)        587           1
test_stdlib_json_serializer[structlog-specific config (Optimized)-Sentry integration disabled]              2,381.0000 (3.17)      4,249.0000 (2.87)      2,723.4591 (3.20)       186.6872 (3.22)      2,679.0000 (3.18)        75.0000 (2.68)        53;69    367.1801 (0.31)        416           1
test_orjson_serializer_non_str_keys[structlog-specific config (Optimized)-Sentry integration enabled]       2,719.0000 (3.62)      4,037.0000 (2.72)      3,066.7479 (3.60)       137.8226 (2.38)      3,073.0000 (3.65)       101.5000 (3.62)        65;37    326.0783 (0.28)        365           1
test_orjson_serializer[structlog-specific config (Optimized)-Sentry integration enabled]                    3,193.0000 (4.25)      4,977.0000 (3.36)      3,291.3095 (3.87)       132.2146 (2.28)      3,247.0000 (3.85)        59.5000 (2.12)        20;30    303.8304 (0.26)        349           1
test_stdlib_json_serializer[structlog-specific config (Optimized)-Sentry integration enabled]               3,591.0000 (4.78)      7,943.0000 (5.36)      4,079.8530 (4.79)       410.0873 (7.08)      4,005.0000 (4.75)       110.7500 (3.96)        16;29    245.1069 (0.21)        279           1
test_orjson_serializer_non_str_keys[stdlib-based config (Legacy)-Sentry integration disabled]               3,871.0000 (5.15)      5,898.0000 (3.98)      4,372.8794 (5.14)       226.7029 (3.92)      4,339.0000 (5.15)       120.2500 (4.29)        34;32    228.6823 (0.19)        257           1
test_orjson_serializer[stdlib-based config (Legacy)-Sentry integration disabled]                            4,260.0000 (5.67)      7,814.0000 (5.27)      4,876.1356 (5.73)       413.1512 (7.14)      4,771.5000 (5.66)       260.0000 (9.29)        29;20    205.0804 (0.17)        236           1
test_orjson_serializer_non_str_keys[stdlib-based config (Legacy)-Sentry integration enabled]                5,051.0000 (6.73)      8,168.0000 (5.51)      5,611.3861 (6.59)       355.9982 (6.15)      5,548.5000 (6.58)       153.0000 (5.46)        22;32    178.2091 (0.15)        202           1
test_orjson_serializer[stdlib-based config (Legacy)-Sentry integration enabled]                             5,532.0000 (7.37)      7,597.0000 (5.13)      6,066.6961 (7.13)       204.5114 (3.53)      6,038.0000 (7.16)       100.2500 (3.58)        21;22    164.8344 (0.14)        181           1
test_stdlib_json_serializer[stdlib-based config (Legacy)-Sentry integration disabled]                      39,498.0000 (52.59)    43,521.0000 (29.37)    40,267.1538 (47.29)      929.6721 (16.06)    39,843.0000 (47.26)    1,043.0000 (37.25)         2;1     24.8341 (0.02)         26           1
test_stdlib_json_serializer[stdlib-based config (Legacy)-Sentry integration enabled]                       39,975.0000 (53.23)    45,698.0000 (30.84)    41,309.9600 (48.52)    1,182.9769 (20.43)    40,979.0000 (48.61)      814.0000 (29.07)         5;3     24.2072 (0.02)         25           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After:
```
---------------------------------------------------------------------------------------------------------------------------------------- benchmark: 14 tests ----------------------------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                                                  Min                    Max                   Mean                StdDev                 Median                   IQR            Outliers         OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_gold_standard_structlog_non_str_keys                                                                     758.0000 (1.0)       1,462.0000 (1.0)         892.9356 (1.0)         61.2913 (1.0)         889.0000 (1.0)         31.0000 (1.0)       194;193  1,119.9016 (1.0)        1288           1
test_gold_standard_structlog                                                                                  872.0000 (1.15)      1,621.0000 (1.11)      1,027.8973 (1.15)        66.6110 (1.09)      1,020.0000 (1.15)        55.5000 (1.79)       154;52    972.8598 (0.87)       1120           1
test_orjson_serializer_non_str_keys[structlog-specific config (Optimized)-Sentry integration disabled]      1,293.0000 (1.71)      3,900.0000 (2.67)      1,527.9706 (1.71)       164.5261 (2.68)      1,511.0000 (1.70)        92.0000 (2.97)        59;39    654.4629 (0.58)        782           1
test_orjson_serializer[structlog-specific config (Optimized)-Sentry integration disabled]                   1,360.0000 (1.79)      3,152.0000 (2.16)      1,659.9354 (1.86)       162.2790 (2.65)      1,639.0000 (1.84)        95.0000 (3.06)        75;50    602.4331 (0.54)        727           1
test_stdlib_json_serializer[structlog-specific config (Optimized)-Sentry integration disabled]              2,059.0000 (2.72)      2,846.0000 (1.95)      2,363.4263 (2.65)       100.1327 (1.63)      2,358.0000 (2.65)        85.5000 (2.76)        94;48    423.1145 (0.38)        495           1
test_orjson_serializer_non_str_keys[structlog-specific config (Optimized)-Sentry integration enabled]       2,350.0000 (3.10)      4,536.0000 (3.10)      2,774.8894 (3.11)       206.2280 (3.36)      2,736.0000 (3.08)       129.0000 (4.16)        62;40    360.3747 (0.32)        416           1
test_orjson_serializer[structlog-specific config (Optimized)-Sentry integration enabled]                    2,526.0000 (3.33)      6,982.0000 (4.78)      2,982.8141 (3.34)       372.8167 (6.08)      2,926.0000 (3.29)       128.0000 (4.13)        23;39    335.2539 (0.30)        398           1
test_stdlib_json_serializer[structlog-specific config (Optimized)-Sentry integration enabled]               3,307.0000 (4.36)      4,934.0000 (3.37)      3,697.3189 (4.14)       184.2203 (3.01)      3,670.0000 (4.13)       228.0000 (7.35)         65;6    270.4663 (0.24)        301           1
test_orjson_serializer_non_str_keys[stdlib-based config (Legacy)-Sentry integration disabled]               3,484.0000 (4.60)      4,631.0000 (3.17)      3,973.2580 (4.45)       144.0494 (2.35)      3,992.0000 (4.49)       103.5000 (3.34)        55;34    251.6826 (0.22)        283           1
test_orjson_serializer[stdlib-based config (Legacy)-Sentry integration disabled]                            3,813.0000 (5.03)      8,377.0000 (5.73)      4,492.0772 (5.03)       492.5548 (8.04)      4,382.0000 (4.93)       244.2500 (7.88)        24;24    222.6142 (0.20)        259           1
test_orjson_serializer_non_str_keys[stdlib-based config (Legacy)-Sentry integration enabled]                4,727.0000 (6.24)     11,622.0000 (7.95)      5,382.4319 (6.03)       722.5231 (11.79)     5,126.0000 (5.77)       383.5000 (12.37)       21;23    185.7896 (0.17)        213           1
test_orjson_serializer[stdlib-based config (Legacy)-Sentry integration enabled]                             5,055.0000 (6.67)      6,693.0000 (4.58)      5,640.4293 (6.32)       191.4146 (3.12)      5,603.0000 (6.30)       146.0000 (4.71)        34;19    177.2915 (0.16)        198           1
test_stdlib_json_serializer[stdlib-based config (Legacy)-Sentry integration disabled]                      38,442.0000 (50.72)    45,758.0000 (31.30)    40,695.7692 (45.58)    1,587.8817 (25.91)    40,133.0000 (45.14)    1,481.0000 (47.77)         4;2     24.5726 (0.02)         26           1
test_stdlib_json_serializer[stdlib-based config (Legacy)-Sentry integration enabled]                       40,148.0000 (52.97)    44,827.0000 (30.66)    41,632.1200 (46.62)    1,116.0308 (18.21)    41,475.0000 (46.65)      919.7500 (29.67)         4;2     24.0199 (0.02)         25           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```