### PR TITLE
💚  Fix Windows package building in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
   package-build:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-2019", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9"]
 
     name: Package build


### PR DESCRIPTION
Pins Windows runners to Windows Server 2019 to fix broken package building on Windows that started on 2022-01-22 at 6:07 AM PST.