### PR TITLE
:construction_worker: Temporarily remove Windows from test matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     name: Python ${{ matrix.python-version }} (${{ matrix.os }})

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-publish-benchmarks:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         library-type: ["pure_python", "c_library"]
 


### PR DESCRIPTION
SSIA.

## Why
- Running tests in isolated subprocesses via `pytest-forked` (to be introduced in #625) is not supported on Windows. 
- Additionally, Windows benchmark tests were extremely long-running, becoming a CI bottleneck and leading to a flaky test suite due to timeouts.