### PR TITLE
🚨  Fix `mypy` warnings: PEP 484 compliance

### DIFF
--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -426,7 +426,7 @@ class SentryBreadcrumbJsonProcessor(structlog_sentry.SentryJsonProcessor):
         level: int = logging.WARNING,
         active: bool = True,
         as_extra: bool = True,
-        tag_keys: Union[List[str], str] = None,
+        tag_keys: Optional[Union[List[str], str]] = None,
     ) -> None:
         self.breadcrumb_level = breadcrumb_level
         super().__init__(

--- a/structlog_sentry_logger/structlog_sentry.py
+++ b/structlog_sentry_logger/structlog_sentry.py
@@ -30,7 +30,7 @@ class SentryProcessor:  # pylint: disable=too-few-public-methods
         level: int = logging.WARNING,
         active: bool = True,
         as_extra: bool = True,
-        tag_keys: Union[List[str], str] = None,
+        tag_keys: Optional[Union[List[str], str]] = None,
         ignore_loggers: Optional[Iterable[str]] = None,
     ) -> None:
         """
@@ -152,7 +152,7 @@ class SentryJsonProcessor(SentryProcessor):  # pylint: disable=too-few-public-me
         level: int = logging.WARNING,
         active: bool = True,
         as_extra: bool = True,
-        tag_keys: Union[List[str], str] = None,
+        tag_keys: Optional[Union[List[str], str]] = None,
     ) -> None:
         super().__init__(
             level=level, active=active, as_extra=as_extra, tag_keys=tag_keys


### PR DESCRIPTION
## WHAT
SSIA.

see: [PEP 484](https://peps.python.org/pep-0484/)

## WHY
e.g., fixes:

```console
mypy.................................................................................Failed
- hook id: mypy
- duration: 27.33s
- exit code: 1

structlog_sentry_logger/_config.py:25: note: In module imported here,
structlog_sentry_logger/__init__.py:4: note: ... from here:
structlog_sentry_logger/structlog_sentry.py: note: In member "__init__" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:33:43: error: Incompatible default
for argument "tag_keys" (default has type "None", argument has type
"Union[List[str], str]")  [assignment]
            tag_keys: Union[List[str], str] = None,
                                              ^~~~
structlog_sentry_logger/structlog_sentry.py:33:43: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
structlog_sentry_logger/structlog_sentry.py:33:43: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
structlog_sentry_logger/structlog_sentry.py: note: In member "__init__" of class "SentryJsonProcessor":
structlog_sentry_logger/structlog_sentry.py:155:43: error: Incompatible default
for argument "tag_keys" (default has type "None", argument has type
"Union[List[str], str]")  [assignment]
            tag_keys: Union[List[str], str] = None,
                                              ^~~~
structlog_sentry_logger/structlog_sentry.py:155:43: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
structlog_sentry_logger/structlog_sentry.py:155:43: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
structlog_sentry_logger/__init__.py:4: note: In module imported here:
structlog_sentry_logger/_config.py: note: In member "__init__" of class "SentryBreadcrumbJsonProcessor":
structlog_sentry_logger/_config.py:429:43: error: Incompatible default for
argument "tag_keys" (default has type "None", argument has type
"Union[List[str], str]")  [assignment]
            tag_keys: Union[List[str], str] = None,
                                              ^~~~
structlog_sentry_logger/_config.py:429:43: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
structlog_sentry_logger/_config.py:429:43: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
Found 3 errors in 2 files (checked 12 source files)
structlog_sentry_logger/structlog_sentry.py: note: In member "__init__" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:33:43: error: Incompatible default
for argument "tag_keys" (default has type "None", argument has type
"Union[List[str], str]")  [assignment]
            tag_keys: Union[List[str], str] = None,
                                              ^~~~
structlog_sentry_logger/structlog_sentry.py:33:43: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
structlog_sentry_logger/structlog_sentry.py:33:43: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
structlog_sentry_logger/structlog_sentry.py: note: In member "__init__" of class "SentryJsonProcessor":
structlog_sentry_logger/structlog_sentry.py:155:43: error: Incompatible default
for argument "tag_keys" (default has type "None", argument has type
"Union[List[str], str]")  [assignment]
            tag_keys: Union[List[str], str] = None,
                                              ^~~~
structlog_sentry_logger/structlog_sentry.py:155:43: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
structlog_sentry_logger/structlog_sentry.py:155:43: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
structlog_sentry_logger/_config.py: note: In member "__init__" of class "SentryBreadcrumbJsonProcessor":
structlog_sentry_logger/_config.py:429:43: error: Incompatible default for
argument "tag_keys" (default has type "None", argument has type
"Union[List[str], str]")  [assignment]
            tag_keys: Union[List[str], str] = None,
                                              ^~~~
structlog_sentry_logger/_config.py:429:43: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
structlog_sentry_logger/_config.py:429:43: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
Found 3 errors in 2 files (checked 11 source files)
```