### PR TITLE
🚨  Fix security scanning for `CVE-2022-42969`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -209,7 +209,8 @@ commands = poetry build
 [testenv:security]
 skip_install = true
 deps = safety
-commands = safety check --full-report -r {toxinidir}/requirements-all.txt
+commands = safety check --full-report -r {toxinidir}/requirements-all.txt \
+    --ignore=51457 # CVE-2022-42969
 
 [testenv:docs]
 extras =


### PR DESCRIPTION
Must follow this up by removing dependence on transitive dependencies:
```shell
❯ poetry show py
 name         : py
 version      : 1.11.0
 description  : library with cross-python path, ini-parsing, io, code, log facilities

required by
 - pytest-forked *
 - pyzmq *
 - tox >=1.4.17
```