### PR TITLE
💚  Fix py39 & py310 MacOS `10.9` wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,8 @@ jobs:
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel} &&
             find {dest_dir} -type f -name '*.whl' -exec bash -c 'mv "$1" "${1//x86_64/${{ matrix.cibw_archs_macos }}}"' bash {} \; &&
             find {dest_dir} -type f -name '*.whl' -exec bash -c 'mv "$1" "${1//10_16/${{ env.macosx_deployment_target_wheel_string }}}"' bash {} \; &&
-            find {dest_dir} -type f -name '*.whl' -exec bash -c 'mv "$1" "${1//11_0/${{ env.macosx_deployment_target_wheel_string }}}"' bash {} \;
+            find {dest_dir} -type f -name '*.whl' -exec bash -c 'mv "$1" "${1//11_0/${{ env.macosx_deployment_target_wheel_string }}}"' bash {} \; &&
+            find {dest_dir} -type f -name '*.whl' -exec bash -c 'mv "$1" "${1//12_0/${{ env.macosx_deployment_target_wheel_string }}}"' bash {} \;
 
       - name: Store the binary wheel
         uses: actions/upload-artifact@v3

--- a/.mutmut-cache
+++ b/.mutmut-cache
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c986609ca261a66da1571dc062e22fee772161038095b06cf1cd591aec8d4c11
+oid sha256:863ed9df66d55ace9bcff9ffb065178e7a4e6a678a9d6ea3c81e8759144b0b2c
 size 135168


### PR DESCRIPTION
## WHAT
SSIA.

## WHY

Due to updates to GitHub `macos-latest` runner image, these versions were incorrectly imputing `12.0` for the MacOS deployment target substring.

e.g.,
```
4 wheels produced in 5 minutes:
  structlog_sentry_logger-0.17.6.dev1668844597-cp310-cp310-macosx_12_0_x86_64.whl   111 kB
  structlog_sentry_logger-0.17.6.dev1668844597-cp37-cp37m-macosx_10_9_x86_64.whl    109 kB
  structlog_sentry_logger-0.17.6.dev1668844597-cp38-cp38-macosx_10_9_x86_64.whl     111 kB
  structlog_sentry_logger-0.17.6.dev1668844597-cp39-cp39-macosx_12_0_x86_64.whl     111 kB
```