### PR TITLE
📝 💚  [docs] Fix auto-generated header anchors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,6 +101,7 @@ autodoc_typehints = "description"  # Show typehints as content of function or me
 # Prefix document path to section labels, to use:
 # `path/to/file:heading` instead of just `heading`
 autosectionlabel_prefix_document = True
+myst_heading_anchors = 3
 
 
 def convert_emoji_shortcodes(app: Sphinx, exception: Exception) -> None:


### PR DESCRIPTION
## WHAT
SSIA.

Auto-generated header anchors have been broken since [myst-parser version 0.17.0](https://github.com/executablebooks/MyST-Parser/releases/tag/v0.17.0)
- https://myst-parser.readthedocs.io/en/latest/develop/_changelog.html#markdown-link-resolution-improvements

## WHY

To fix documentation building.