### PR TITLE
🏗️  Make documentation browser launching opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
         uses: "codecov/codecov-action@v3.1.1"
         with:
           file: ./.tox/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   # Documentation build testing jobs ------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,8 @@ jobs:
 
       - name: Build Documentation
         run: |
-          make docs-html
+          make docs-html \
+            LAUNCH_DOCS_PREVIEW=false
 
   # Mutation testing jobs ------------------------
   test-mutations:

--- a/Makefile
+++ b/Makefile
@@ -224,8 +224,9 @@ pre-commit-%:
 ## `make docs-html` builds the docs in HTML format,
 ## `make docs-confluence` builds and publishes the docs on confluence (see `docs/source/conf.py` for details),
 ## `make docs-clean` cleans the docs build directory)
+docs-%: LAUNCH_DOCS_PREVIEW ?= true
 docs-%:
-	$(MAKE) $* -C docs
+	$(MAKE) $* LAUNCH_DOCS_PREVIEW=$(LAUNCH_DOCS_PREVIEW) -C docs
 
 .PHONY: test-docs
 ## Test documentation format/syntax

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -28,12 +28,25 @@ clean:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: LAUNCH_DOCS_PREVIEW ?=false
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 ifneq ($(filter html,$(MAKECMDGOALS)),)
+ifneq ($(LAUNCH_DOCS_PREVIEW),false)
+	$(MAKE) launch-docs-in-browser
+endif
+endif
+
+.PHONY: launch-docs-in-browser
+launch-docs-in-browser: PRINTF_RED_TEXT_FORMAT_STR := \033[0;31m%s\033[0m\n
+launch-docs-in-browser: PRINTF_GREEN_TEXT_FORMAT_STR := \033[0;32m%s\033[0m\n
+launch-docs-in-browser:
 ifneq ($(shell command -v open),)
 	@echo
-	@echo "Launching docs browser preview."
+	@printf "$(PRINTF_GREEN_TEXT_FORMAT_STR)" "Launching docs browser preview."
 	@open -a "Google Chrome" "$(BUILDDIR)/html/index.html"
-endif
+else
+	@echo
+	@printf "$(PRINTF_RED_TEXT_FORMAT_STR)"  "Can't launch docs preview in browser."
+	@echo "To view the docs, you may manually open the home page in your browser: $(BUILDDIR)/html/index.html"
 endif


### PR DESCRIPTION
## What
SSIA.

## Why
To make non-local documentation building more robust. Fixes documentation building test CI job errors.

Reference:
- TeoZosa/cookiecutter-cruft-poetry-tox-pre-commit-ci-cd#849