### PR TITLE
👷 Patch deprecated GitHub Actions `set-output` commands

### DIFF
--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -70,11 +70,11 @@ jobs:
             make "tox-${TOX_TESTENV}"
 
             BENCHMARK_FILE=$(find .benchmarks -maxdepth 2 -type f -name "*.json" | sort  --version-sort --reverse | tail -n 1)
-            echo "::set-output name=benchmark_file_path::${BENCHMARK_FILE}"
+            echo "benchmark_file_path=${BENCHMARK_FILE}" >> $GITHUB_OUTPUT
 
             ENV_DIR_NAME=$(basename "${BENCHMARK_FILE%/*}" | tr '-' '/')
             NAMESPACED_TARGET_OUTPUT_DIR="${ENV_DIR_NAME}/${{ matrix.library-type }}"
-            echo "::set-output name=target_output_dir::${NAMESPACED_TARGET_OUTPUT_DIR}"
+            echo "target_output_dir=${NAMESPACED_TARGET_OUTPUT_DIR}" >> $GITHUB_OUTPUT
 
       - name: Store the environment-specific benchmarks
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check if there is a parent commit
         id: check-parent-commit
         run: |
-          echo "::set-output name=sha::$(git rev-parse --verify --quiet HEAD^)"
+          echo "sha=$(git rev-parse --verify --quiet HEAD^)" >> $GITHUB_OUTPUT
 
       - name: Detect new version tag
         id: detect-new-version-tag
@@ -53,7 +53,7 @@ jobs:
           git checkout "${BRANCH_NAME}"
           CURRENT_COMMIT_VER=$(make get-project-version-number)
           if [[ "${PARENT_COMMIT_VER}" != "${CURRENT_COMMIT_VER}" ]]; then
-            echo "::set-output name=tag::${CURRENT_COMMIT_VER}"
+            echo "tag=${CURRENT_COMMIT_VER}" >> $GITHUB_OUTPUT
           fi
 
       - name: Bump version for developmental release
@@ -64,7 +64,7 @@ jobs:
           VERSION=$(make get-project-version-number) &&
           DEV_VERSION="${VERSION}.dev.$(date +%s)" &&
           poetry version "${DEV_VERSION}" &&
-          echo "::set-output name=version::${DEV_VERSION}"
+          echo "version=${DEV_VERSION}" >> $GITHUB_OUTPUT
 
   # Package build ----------------------
   package-build:
@@ -142,14 +142,14 @@ jobs:
         run: |
           VERSION="${{ needs.get-tag-xor-dev-version.outputs.dev-version }}"
           poetry version "${VERSION}"
-          echo "::set-output name=is_testing::true"
+          echo "is_testing=true" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Log package version
         id: log-package-version
         run: |
           VERSION=$(make get-project-version-number)
-          echo "::set-output name=version::${VERSION}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Setup QEMU


### PR DESCRIPTION
## WHAT

Migrates `set-output` commands to use [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).

## WHY
To fix deprecation warnings and prevent CI breakage once `set-output` is fully deprecated.
- see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

