### PR TITLE
💚 Fix benchmarks not being published on pushes to `master`

### DIFF
--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Publish benchmarks to GH pages
         uses: TeoZosa/github-action-benchmark@v1.8.2
-        if: github.event.workflow_run.head_branch == 'master'
+        if: github.ref == 'refs/heads/master'
         with:
           tool: 'pytest'
           benchmark-data-dir-path: dev/bench/${{ steps.performance-testing.outputs.target_output_dir }}


### PR DESCRIPTION
## WHAT
SSIA.

## WHY
Benchmarks publishing has been broken since #495.