### PR TITLE
💚 Fix benchmarks output capture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,7 @@ ignore-imports = "yes"
 min-similarity-lines = 5
 
 [tool.pytest.ini_options]
-addopts = ["-rfsxX", "-l", "--tb=short", "--strict-markers", "-vv", "--forked", "--emoji", "--xdoctest"]
+addopts = ["-rfsxX", "-l", "--tb=short", "--strict-markers", "-vv", "--emoji", "--xdoctest"]
 xfail_strict = true
 testpaths = ["tests",]
 norecursedirs = [".*", "*.egg", "build", "dist",]

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ passenv =
     https_proxy
     no_proxy
 commands = pytest \
+           --forked \
            --cov={toxinidir}/structlog_sentry_logger \
            --cov={toxinidir}/docs_src \
            --cov-config={toxinidir}/pyproject.toml \


### PR DESCRIPTION
## WHAT
SSIA via only forking tests into boxed subprocesses for the main test suite.

## WHY
Benchmarks output capture broken since #625.