### PR TITLE
💚  Fix flaky documentation building CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,6 @@ jobs:
           key: venv-${{ runner.os }}-CPython${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
           make install-dependencies
 


### PR DESCRIPTION
## WHAT
SSIA. 
- caused by cached `.venv`s that are flagged as broken
- ref: TeoZosa/cookiecutter-cruft-poetry-tox-pre-commit-ci-cd#872

## WHY
To minimize false-positive test failures. 