### PR TITLE
👷 :package: Only build against optimized `orjson` wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,11 +176,18 @@ jobs:
           # Install rust on Linux runners for orjson wheel builds which use maturin
           # https://github.com/Daggy1234/polaroid/blob/ace9a6eee74ee9c30edd0d350d65e2f3b4d8430c/.github/workflows/publish.yml#L29
           CIBW_BEFORE_ALL_LINUX: >
-            curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y &&
+            curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y &&
             yum install -y openssl-devel || apk add openssl-dev
           CIBW_ENVIRONMENT_LINUX: >
             PATH="$PATH:$HOME/.cargo/bin"
             CARGO_NET_GIT_FETCH_WITH_CLI="true"
+
+          # Pass orjson build args to maturin
+          #
+          # Note: this is global to *all* maturin wheel builds which may be
+          # problematic if, in the future, multiple build dependencies use
+          # maturin and must be built from source
+          MATURIN_PEP517_ARGS: "--strip --out dist --features=unstable-simd,yyjson"
 
           # On a Linux Intel runner with qemu installed,
           # build 64-bit Intel and ARM wheels


### PR DESCRIPTION
## WHAT

Follow-up to:
- #732 

> **Note** 
> Only necessary if `orjson` did not already build & publish a platform-compatible wheel to PyPI (the wheels published to PyPI are already built with these configurations).

## WHY

For consistency with the PyPI-published `orjson` wheels.

References:
- `MATURIN_PEP517_ARGS`: PyO3/maturin#1090
- `orjson` build options: https://github.com/ijl/orjson/blob/45ad4a456bf3180c223ccca8433f7a2adc90a449/.github/workflows/musllinux.yaml#L34-L37