### PR TITLE
🔊 Update setup meta logger log messages

### DIFF
--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -160,6 +160,8 @@ def get_handlers(module_name: str) -> dict:
     }
     default_handler = base_handlers[default_key]
     if _feature_flags.is_prettified_output_formatting_requested():
+        __LOGGER.debug("initializing rich formatting logger")
+
         # Add logfile handler
         filename_handler = get_dev_local_filename_handler(module_name)
         if filename_handler is not None:

--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -197,7 +197,7 @@ def get_dev_local_filename_handler(module_name: str) -> Optional[dict]:
     ]:
         if mkdir_logs_dir(log_data_dir):
             __LOGGER.info(
-                "logs directory created",
+                "saving JSON logs to local log directory",
                 log_dir=str(log_data_dir),
             )
 

--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -196,7 +196,7 @@ def get_dev_local_filename_handler(module_name: str) -> Optional[dict]:
         fallback_log_data_root_dir / ".logs",
     ]:
         if mkdir_logs_dir(log_data_dir):
-            __LOGGER.info(
+            __LOGGER.debug(
                 "saving JSON logs to local log directory",
                 log_dir=str(log_data_dir),
             )

--- a/tests/docs_src/test_pure_structlog_logging_without_sentry.py
+++ b/tests/docs_src/test_pure_structlog_logging_without_sentry.py
@@ -75,7 +75,7 @@ def test_dev_local(capsys: CaptureFixture, caplog: LogCaptureFixture, monkeypatc
     # reloads/logging re-configurations, so truncating it as in the above call actually
     # chops off more than the timestamp, but the resulting string so happens to line up
     # with the below checks.
-    assert library_log.startswith("logs directory created         log_dir=")
+    assert library_log.startswith("saving JSON logs to local log directory log_dir=")
     assert library_log.endswith(str(pathlib.Path("structlog-sentry-logger/.logs")))
 
     assert relevant_actual == relevant_expected

--- a/tests/docs_src/test_pure_structlog_logging_without_sentry.py
+++ b/tests/docs_src/test_pure_structlog_logging_without_sentry.py
@@ -67,7 +67,7 @@ def test_dev_local(capsys: CaptureFixture, caplog: LogCaptureFixture, monkeypatc
 
     # Ignore timestamped portion
     example_timestamp_substr = "\x1b[2m2021-10-25T16:15:30.993152Z\x1b"
-    library_log, relevant_actual = (
+    init_log, library_log, relevant_actual = (
         log[len(example_timestamp_substr) :] for log in tests.utils.parse_logs_from_stdout(capsys)
     )
 
@@ -75,6 +75,7 @@ def test_dev_local(capsys: CaptureFixture, caplog: LogCaptureFixture, monkeypatc
     # reloads/logging re-configurations, so truncating it as in the above call actually
     # chops off more than the timestamp, but the resulting string so happens to line up
     # with the below checks.
+    assert init_log == "initializing rich formatting logger"
     assert library_log.startswith("saving JSON logs to local log directory log_dir=")
     assert library_log.endswith(str(pathlib.Path("structlog-sentry-logger/.logs")))
 


### PR DESCRIPTION
## WHAT 
- Updates the `.logs` directory setup message (previously implied that the library created the `.logs` directory even if it already existed) and downgrades it to a debug log
- Adds a new debug log message when instantiating a rich formatting logger

## WHY
To improve DX for users. 