### PR TITLE
:construction_worker: Group `build` PRs in release notes under "Continuous Integration Build System" label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,18 +12,17 @@ categories:
     label: "performance"
   - title: ":white_check_mark: Testing"
     label: "testing"
-  - title: ":construction_worker: Continuous Integration"
+  - title: ":construction_worker: Continuous Integration Build System"
     labels:
       - "ci"
       - "github_actions"
+      - "build"
   - title: ":memo: Documentation"
     label: "documentation"
   - title: ":recycle: Refactoring"
     label: "refactoring"
   - title: ":package: Dependencies"
-    labels:
-      - "dependencies"
-      - "build"
+    label: "dependencies"
 template: |
   ## Changes
 


### PR DESCRIPTION
## WHAT
SSIA. 

## WHY
For better logical grouping; these were previously grouped under the "Dependency" label despite being mostly orthogonal to dependency-related changes.