### PR TITLE
🐛 Fix library meta logger not honoring user-requested log level filtering & rich formatting logging

### DIFF
--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -400,7 +400,8 @@ def add_severity_field_from_level_if_in_cloud_environment(
 def __get_meta_logger() -> Any:
     """Meta-logger to emit messages generated during logger configuration"""
     set_optimized_structlog_config()
-    logger = structlog.get_logger("structlog_sentry_logger._config")
+    logger_name = "structlog_sentry_logger._config"
+    logger = structlog.get_logger(logger_name).bind(logger=logger_name)
     structlog.reset_defaults()
     return logger
 

--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -399,7 +399,12 @@ def add_severity_field_from_level_if_in_cloud_environment(
 
 def __get_meta_logger() -> Any:
     """Meta-logger to emit messages generated during logger configuration"""
-    set_optimized_structlog_config()
+    if _feature_flags.is_prettified_output_formatting_requested():
+        # The following line is covered by unit tests but coverage doesn't get picked up
+        # for some reason
+        set_stdlib_based_structlog_config()  # pragma: no cover
+    else:
+        set_optimized_structlog_config()
     logger_name = "structlog_sentry_logger._config"
     logger = structlog.get_logger(logger_name).bind(logger=logger_name)
     structlog.reset_defaults()

--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -160,7 +160,6 @@ def get_handlers(module_name: str) -> dict:
     }
     default_handler = base_handlers[default_key]
     if _feature_flags.is_prettified_output_formatting_requested():
-        __LOGGER.debug("initializing rich formatting logger")
 
         # Add logfile handler
         filename_handler = get_dev_local_filename_handler(module_name)

--- a/tests/docs_src/test_pure_structlog_logging_without_sentry.py
+++ b/tests/docs_src/test_pure_structlog_logging_without_sentry.py
@@ -1,5 +1,4 @@
 import importlib
-import pathlib
 import sys
 from types import ModuleType
 from typing import List
@@ -67,17 +66,8 @@ def test_dev_local(capsys: CaptureFixture, caplog: LogCaptureFixture, monkeypatc
 
     # Ignore timestamped portion
     example_timestamp_substr = "\x1b[2m2021-10-25T16:15:30.993152Z\x1b"
-    init_log, library_log, relevant_actual = (
-        log[len(example_timestamp_substr) :] for log in tests.utils.parse_logs_from_stdout(capsys)
-    )
-
-    # Note: library meta-logger log format is slightly different due to the module
-    # reloads/logging re-configurations, so truncating it as in the above call actually
-    # chops off more than the timestamp, but the resulting string so happens to line up
-    # with the below checks.
-    assert init_log == "initializing rich formatting logger"
-    assert library_log.startswith("saving JSON logs to local log directory log_dir=")
-    assert library_log.endswith(str(pathlib.Path("structlog-sentry-logger/.logs")))
+    log = tests.utils.parse_logs_from_stdout(capsys)[0]
+    relevant_actual = log[len(example_timestamp_substr) :]
 
     assert relevant_actual == relevant_expected
 

--- a/tests/structlog_sentry_logger/test__config.py
+++ b/tests/structlog_sentry_logger/test__config.py
@@ -444,25 +444,14 @@ class TestCloudLogging:  # pylint: disable=too-few-public-methods
             )
 
         # Parse logs
-        library_log, test_log = tests.utils.read_json_logs_from_stdout(capsys)
-        if not (isinstance(test_log, dict) and isinstance(library_log, dict)):
-            raise NotImplementedError("Captured log messages not a supported type")
+        test_log = tests.utils.read_json_logs_from_stdout(capsys)[0]
+        if not isinstance(test_log, dict):
+            raise NotImplementedError("Captured log message not a supported type")
 
         cloud_logging_log_level_key, python_log_level_key = "severity", "level"
         # Validate Cloud Logging key correctly overwritten
         assert (
             test_log[python_log_level_key] == test_log[cloud_logging_log_level_key] != orig_cloud_logging_log_key_value
-        )
-
-        # Validate debug log schema
-        assert library_log[python_log_level_key] == "warning" != orig_cloud_logging_log_key_value
-        assert library_log["src_key"] == python_log_level_key
-        assert library_log["dest_key"] == cloud_logging_log_level_key
-        assert library_log["old_value"] == orig_cloud_logging_log_key_value
-        assert library_log["new_value"] == "debug"
-        assert (
-            library_log["logger_that_used_reserved_key"]
-            == logger._context["logger"]  # pylint: disable=protected-access
         )
 
 


### PR DESCRIPTION
## WHAT
Fixes bugs around meta logger playing nice with user configurations.

## WHY
To improve DX, especially around reducing frustration on library logs showing up when they shouldn't be.