### PR TITLE
✨  Make `Sentry` integration an optional extra

### DIFF
--- a/.mutmut-cache
+++ b/.mutmut-cache
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:365edd999873753ff7c4e29d2cd533b832152ef9a3f94730ea449b2b75decc73
-size 139264
+oid sha256:82a449b1dd21036f1f672b96fed66a1c79e1e9fcda926e99cf15e8570252927f
+size 143360

--- a/Makefile
+++ b/Makefile
@@ -78,20 +78,20 @@ endif
 .PHONY: install-dependencies
 ## Install Python dependencies specified in `poetry.lock`
 install-dependencies:
-	poetry install --no-interaction --no-root --with docs -vv
+	poetry install --no-interaction --all-extras --no-root --with docs -vv
 
 .PHONY: install-project
 ## Install structlog-sentry-logger source code (in editable mode)
 install-project:
-	poetry install --no-interaction -vv
+	poetry install --all-extras --no-interaction -vv
 	$(MAKE) clean
 
 .PHONY: generate-requirements
 ## Generate project requirements files from `pyproject.toml`
 generate-requirements:
-	poetry export --format requirements.txt --without-hashes --output requirements.txt # subset
-	poetry export --with dev --format requirements.txt --without-hashes --output requirements-dev.txt # superset w/o docs
-	poetry export --with dev,docs --format requirements.txt --without-hashes --output requirements-all.txt # superset
+	poetry export --extras=sentry --format requirements.txt --without-hashes --output requirements.txt # subset
+	poetry export --extras=sentry --with dev --format requirements.txt --without-hashes --output requirements-dev.txt # superset w/o docs
+	poetry export --extras=sentry --with dev,docs --format requirements.txt --without-hashes --output requirements-all.txt # superset
 
 .PHONY: clean-requirements
 ## Clean generated project requirements files

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ endif
 .PHONY: install-dependencies
 ## Install Python dependencies specified in `poetry.lock`
 install-dependencies:
-	poetry install --no-interaction --all-extras --no-root --with docs -vv
+	poetry install --all-extras --no-root --with=docs --no-interaction -vv
 
 .PHONY: install-project
 ## Install structlog-sentry-logger source code (in editable mode)
@@ -90,8 +90,8 @@ install-project:
 ## Generate project requirements files from `pyproject.toml`
 generate-requirements:
 	poetry export --extras=sentry --format requirements.txt --without-hashes --output requirements.txt # subset
-	poetry export --extras=sentry --with dev --format requirements.txt --without-hashes --output requirements-dev.txt # superset w/o docs
-	poetry export --extras=sentry --with dev,docs --format requirements.txt --without-hashes --output requirements-all.txt # superset
+	poetry export --extras=sentry --with=dev --format requirements.txt --without-hashes --output requirements-dev.txt # superset w/o docs
+	poetry export --extras=sentry --with=dev,docs --format requirements.txt --without-hashes --output requirements-all.txt # superset
 
 .PHONY: clean-requirements
 ## Clean generated project requirements files

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Table of Contents
 - [:tada: Installation](#tada-installation)
 - [:rocket: Usage](#rocket-usage)
   * [:loud_sound: Pure `structlog` Logging (Without Sentry)](#loud_sound-pure-structlog-logging-without-sentry)
-  * [:outbox_tray: Log Custom Context Directly to Sentry](#outbox_tray-log-custom-context-directly-to-sentry)
+  * [:outbox_tray: Log Custom Context Directly to Sentry (optional)](#outbox_tray-log-custom-context-directly-to-sentry-optional)
   * [:cloud: Cloud Logging Compatibility](#cloud-cloud-logging-compatibility)
 - [:chart_with_downwards_trend: Output: Formatting & Storage](#chart_with_downwards_trend-output-formatting--storage)
 - [:clipboard: Summary](#clipboard-summary)
@@ -126,6 +126,12 @@ Table of Contents
 
  ```shell script
 pip install structlog-sentry-logger
+```
+
+Optionally, install Sentry integration with
+
+ ```shell script
+pip install "structlog-sentry-logger[sentry]"
 ```
 
 :rocket: Usage
@@ -166,13 +172,14 @@ Which automatically produces this:
 ```
 
 
-:outbox_tray: Log Custom Context Directly to Sentry
+:outbox_tray: Log Custom Context Directly to Sentry (optional)
 ------------------------------------------------
 
-Incorporate custom messages in your exception handling which will automatically be
-reported to Sentry (thanks to the `structlog-sentry` module). To enable this behavior,
-export the `STRUCTLOG_SENTRY_LOGGER_CLOUD_SENTRY_INTEGRATION_MODE_ON`
-environment variable.
+If you installed the library with the optional Sentry integration you can incorporate
+custom messages in your exception handling which will automatically be
+reported to Sentry (thanks to the [`structlog-sentry`](https://github.com/kiwicom/structlog-sentry)
+module). To enable this behavior, export the
+`STRUCTLOG_SENTRY_LOGGER_CLOUD_SENTRY_INTEGRATION_MODE_ON` environment variable.
 
 An easy way to do this is to put it into a local `.env` file[^2]:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1490,7 +1490,7 @@ name = "sentry-sdk"
 version = "1.12.1"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -2020,10 +2020,13 @@ python-versions = ">=3.7"
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+sentry = ["sentry-sdk"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<3.12"
-content-hash = "f041d266bd6424f1855a566d22cab7db206f272174ce746db367a717f51709f2"
+content-hash = "b8fe1bf11e5fa9b2bf1ab6951007a6e0dd94b579b54f6803d447c5d9b04061fc"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,11 @@ gitpython = "^3.1.7"
 orjson = "^3.6.4"
 python-dotenv = ">=0.19"
 rich = ">=10.12,<14.0"
-sentry-sdk = ">0.17.0"
+sentry-sdk = { version = ">0.17.0", optional = true }
 structlog = ">=21.1,<23.0"
+
+[tool.poetry.extras]
+sentry = ["sentry-sdk"]
 
 [tool.poetry.dev-dependencies]
 # Standardized Developer Workflow Orchestration

--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -22,7 +22,11 @@ import orjson  # type: ignore
 import structlog
 
 from structlog_sentry_logger import _feature_flags
-from structlog_sentry_logger.structlog_sentry import SentryBreadcrumbJsonProcessor
+
+try:
+    from structlog_sentry_logger.structlog_sentry import SentryBreadcrumbJsonProcessor
+except ImportError:
+    SentryBreadcrumbJsonProcessor = None  # type: ignore
 
 
 @dataclasses.dataclass
@@ -271,7 +275,7 @@ def set_stdlib_based_structlog_config() -> None:
         add_line_number_and_func_name,
     ]
 
-    if _feature_flags.is_sentry_integration_mode_requested():
+    if SentryBreadcrumbJsonProcessor is not None and _feature_flags.is_sentry_integration_mode_requested():
         structlog_processors.append(SentryBreadcrumbJsonProcessor(level=logging.ERROR, tag_keys="__all__"))
 
     if (
@@ -310,7 +314,7 @@ def set_optimized_structlog_config() -> None:
         add_line_number_and_func_name,
         _TIMESTAMPER,
     ]
-    if _feature_flags.is_sentry_integration_mode_requested():
+    if SentryBreadcrumbJsonProcessor is not None and _feature_flags.is_sentry_integration_mode_requested():
         processors.append(SentryBreadcrumbJsonProcessor(level=logging.ERROR, tag_keys="__all__"))
 
     if (

--- a/structlog_sentry_logger/structlog_sentry.py
+++ b/structlog_sentry_logger/structlog_sentry.py
@@ -14,7 +14,7 @@ import sys
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import structlog
-from sentry_sdk import capture_event
+from sentry_sdk import add_breadcrumb, capture_event
 from sentry_sdk.integrations.logging import ignore_logger as logging_int_ignore_logger
 from sentry_sdk.utils import event_from_exception
 
@@ -173,3 +173,49 @@ class SentryJsonProcessor(SentryProcessor):  # pylint: disable=too-few-public-me
         if logger_name not in self._ignored:
             logging_int_ignore_logger(logger_name)
             self._ignored.add(logger_name)
+
+
+# Extension to the vendored `structlog-sentry` package
+class SentryBreadcrumbJsonProcessor(SentryJsonProcessor):
+    """
+    Addresses: `SentryJsonProcessor breaks logging breadcrumbs #25`_
+    (source_)
+
+    .. _`SentryJsonProcessor breaks logging breadcrumbs #25`: https://github.com/kiwicom/structlog-sentry/issues/25
+    .. _`source`: https://github.com/kiwicom/structlog-sentry/issues/25#issuecomment-660292563
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        breadcrumb_level: int = logging.INFO,
+        level: int = logging.WARNING,
+        active: bool = True,
+        as_extra: bool = True,
+        tag_keys: Optional[Union[List[str], str]] = None,
+    ) -> None:
+        self.breadcrumb_level = breadcrumb_level
+        super().__init__(level=level, active=active, as_extra=as_extra, tag_keys=tag_keys)
+
+    @staticmethod
+    def save_breadcrumb(logger: Any, event_dict: structlog.types.EventDict) -> None:
+        data = event_dict.copy()  # type: ignore[attr-defined]
+        data.pop("event")
+        data.pop("logger", None)
+        data.pop("level", None)
+        data.pop("timestamp", None)
+        breadcrumb = {
+            "ty": "log",
+            "level": event_dict["level"].lower(),
+            "category": event_dict.get("logger") or logger.name,
+            "message": event_dict["event"],
+            "data": data,
+        }
+        add_breadcrumb(breadcrumb, hint={"event_dict": event_dict})
+
+    def __call__(self, logger: Any, method: str, event_dict: structlog.types.EventDict) -> structlog.types.EventDict:
+        do_breadcrumb = getattr(logging, event_dict["level"].upper()) >= self.breadcrumb_level
+
+        if do_breadcrumb:
+            self.save_breadcrumb(logger, event_dict)
+
+        return super().__call__(logger=logger, method=method, event_dict=event_dict)


### PR DESCRIPTION
## WHAT

SSIA.

## WHY

To reduce dependency conflict surface area.

Additionally, Sentry usage is operationally sensitive. The Sentry client library should not be installed unless users *explicitly* opt-into it. This eliminates the Sentry client library (and associated transitive dependencies) as a source of application security vulnerabilities.