### PR TITLE
✨ Remove dependence on available system `git` executable

### DIFF
--- a/.mutmut-cache
+++ b/.mutmut-cache
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82a449b1dd21036f1f672b96fed66a1c79e1e9fcda926e99cf15e8570252927f
+oid sha256:fb38823abc9c4ec453d12c802cf17fbe6bbd5215feda91d0c5fae8f8962791f3
 size 143360


### PR DESCRIPTION
## WHAT
SSIA.

## WHY

To expand compatibility with different runtime environments (e.g., lambdas which may not have `git` installed)
- ref: #363 