### PR TITLE
:heavy_minus_sign: Remove dev dependency: `typeguard`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1849,18 +1849,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "typeguard"
-version = "2.13.3"
-description = "Run-time type checker for Python"
-category = "dev"
-optional = false
-python-versions = ">=3.5.3"
-
-[package.extras]
-doc = ["sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["mypy", "pytest", "typing-extensions"]
-
-[[package]]
 name = "typer"
 version = "0.6.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -2026,7 +2014,7 @@ sentry = ["sentry-sdk"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<3.12"
-content-hash = "09dfcaecff95d763d06b43bc67cb79d74224a6d989a6f26607310e914da93a4d"
+content-hash = "50ce8176e4d4c7d869b00acbfcf1c9a2334be94909f158f123aabe5682e8ea90"
 
 [metadata.files]
 alabaster = [
@@ -3091,10 +3079,6 @@ typed-ast = [
     {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
     {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
-]
-typeguard = [
-    {file = "typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1"},
-    {file = "typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4"},
 ]
 typer = [
     {file = "typer-0.6.1-py3-none-any.whl", hash = "sha256:54b19e5df18654070a82f8c2aa1da456a4ac16a2a83e6dcd9f170e291c56338e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ cruft = "^2.12.0" # Automated Cookiecutter template synchronization
 
 # Type Checking and Data Validation
 mypy = "^0.991" # Static type checker (includes Mypyc Python module to C-Extension compiler, enabled by standard Python type annotations)
-typeguard = "^2.13.3" # Runtime type checker; Note: Mypyc-compiled C-extensions also perform runtime type checking.
 
 # Testing
 pytest = "^7.2.0"

--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -121,7 +121,7 @@ def get_caller_name_from_frames() -> str:
 
 def _get_caller_stack_frame_and_name() -> Tuple[FrameType, str]:
     return structlog._frames._find_first_app_frame_and_name(  # pylint:disable=protected-access
-        additional_ignores=["structlog_sentry_logger", "typeguard"]
+        additional_ignores=["structlog_sentry_logger"]
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ commands = pytest \
            --cov={toxinidir}/docs_src \
            --cov-config={toxinidir}/pyproject.toml \
            --junitxml={toxworkdir}/junit.{envname}.xml \
-           --typeguard-packages=structlog_sentry_logger \
            --basetemp={envtmpdir} \
            -n={env:PYTEST_XDIST_PROC_NR:auto} \
            {env:TESTENV_SPECIFIED_PYTEST_FLAGS:} \


### PR DESCRIPTION
## WHAT
SSIA.

## WHY

Typeguard is redundant in the context of static type-checking via Mypy and implicit runtime type-checking via C-compilation. This also will unblock migrated to postponed annotation evaluation ([PEP 563](https://peps.python.org/pep-0563/)).