### PR TITLE
♻️  Postpone annotation evaluation (PEP 563)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,9 +1,11 @@
 """Sphinx configuration."""
+from __future__ import annotations
+
 import datetime
 import pathlib
 import re
 import sys
-from typing import List, Match
+from typing import Match
 
 import emoji
 import importlib_metadata
@@ -54,7 +56,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 #   directories to ignore when looking for source files.
 #   This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: List[str] = [
+exclude_patterns: list[str] = [
     ".DS_Store",
     ".venv",
     "_build",

--- a/structlog_sentry_logger/__init__.py
+++ b/structlog_sentry_logger/__init__.py
@@ -1,5 +1,5 @@
 """Structlog Sentry Logger"""
-from typing import List
+from __future__ import annotations
 
 from structlog_sentry_logger._config import (
     get_config_dict,
@@ -9,7 +9,7 @@ from structlog_sentry_logger._config import (
 )
 from structlog_sentry_logger._feature_flags import _load_library_specific_env_vars
 
-__all__: List[str] = [
+__all__: list[str] = [
     "get_config_dict",
     "get_logger",
     "get_namespaced_module_name",

--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import datetime
 import inspect
@@ -9,7 +11,7 @@ import pathlib
 import tempfile
 import warnings
 from types import FrameType
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable
 
 try:
     import git
@@ -78,7 +80,7 @@ def get_config_dict() -> dict:
     return get_logging_config(caller_name)
 
 
-def get_logger(name: Optional[str] = None) -> Any:
+def get_logger(name: str | None = None) -> Any:
     """
     Convenience function that returns a logger
 
@@ -119,7 +121,7 @@ def get_caller_name_from_frames() -> str:
     return caller_name
 
 
-def _get_caller_stack_frame_and_name() -> Tuple[FrameType, str]:
+def _get_caller_stack_frame_and_name() -> tuple[FrameType, str]:
     return structlog._frames._find_first_app_frame_and_name(  # pylint:disable=protected-access
         additional_ignores=["structlog_sentry_logger"]
     )
@@ -129,7 +131,7 @@ def is_caller_main(caller_name: str) -> bool:  # Gratuitous indirection for test
     return caller_name == "__main__"
 
 
-def get_namespaced_module_name(__file__: Union[pathlib.Path, str]) -> str:
+def get_namespaced_module_name(__file__: pathlib.Path | str) -> str:
     fully_qualified_path = pathlib.Path(__file__).resolve()
     prefix_dir = str(ROOT_DIR) if str(ROOT_DIR) in str(fully_qualified_path) else "/"
     namespaces = fully_qualified_path.relative_to(prefix_dir).with_suffix("").parts
@@ -181,7 +183,7 @@ def get_handlers(module_name: str) -> dict:
     return base_handlers
 
 
-def get_dev_local_filename_handler(module_name: str) -> Optional[dict]:
+def get_dev_local_filename_handler(module_name: str) -> dict | None:
     """Builds logfile handler configs
 
     Before building the logfile handler configurations, this function attempts to
@@ -265,8 +267,8 @@ def get_formatters() -> dict:
 
 def serializer(
     *args: Any,
-    default: Optional[Callable[[Any], Any]] = None,
-    option: Optional[int] = orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS,
+    default: Callable[[Any], Any] | None = None,
+    option: int | None = orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS,
 ) -> str:
     if _CONFIGS.use_orjson:
         return orjson.dumps(*args, default=default, option=option).decode()  # type: ignore[misc]
@@ -345,8 +347,8 @@ def set_optimized_structlog_config() -> None:
 
 def serializer_bytes(
     *args: Any,
-    default: Optional[Callable[[Any], Any]] = None,
-    option: Optional[int] = orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS,
+    default: Callable[[Any], Any] | None = None,
+    option: int | None = orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS,
 ) -> bytes:
     if _CONFIGS.use_orjson:
         return orjson.dumps(*args, default=default, option=option)  # type: ignore[misc]

--- a/structlog_sentry_logger/structlog_sentry.py
+++ b/structlog_sentry_logger/structlog_sentry.py
@@ -9,9 +9,11 @@
 
 """
 # pylint: disable=unsubscriptable-object
+from __future__ import annotations
+
 import logging
 import sys
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Iterable
 
 import structlog
 from sentry_sdk import add_breadcrumb, capture_event
@@ -30,8 +32,8 @@ class SentryProcessor:  # pylint: disable=too-few-public-methods
         level: int = logging.WARNING,
         active: bool = True,
         as_extra: bool = True,
-        tag_keys: Optional[Union[List[str], str]] = None,
-        ignore_loggers: Optional[Iterable[str]] = None,
+        tag_keys: list[str] | str | None = None,
+        ignore_loggers: Iterable[str] | None = None,
     ) -> None:
         """
         :param level: events of this or higher levels will be reported to Sentry.
@@ -47,12 +49,12 @@ class SentryProcessor:  # pylint: disable=too-few-public-methods
         self.tag_keys = tag_keys
         self._as_extra = as_extra
         self._original_event_dict: structlog.types.EventDict = {}
-        self._ignored_loggers: Set[str] = set()
+        self._ignored_loggers: set[str] = set()
         if ignore_loggers is not None:
             self._ignored_loggers.update(set(ignore_loggers))
 
     @staticmethod
-    def _get_logger_name(logger: Any, event_dict: structlog.types.EventDict) -> Optional[str]:
+    def _get_logger_name(logger: Any, event_dict: structlog.types.EventDict) -> str | None:
         """Get logger name from event_dict with a fallbacks to logger.name and record.name
 
         :param logger: logger instance
@@ -72,7 +74,7 @@ class SentryProcessor:  # pylint: disable=too-few-public-methods
 
         return logger_name
 
-    def _get_event_and_hint(self, event_dict: structlog.types.EventDict) -> Tuple[dict, Optional[Dict[str, Any]]]:
+    def _get_event_and_hint(self, event_dict: structlog.types.EventDict) -> tuple[dict, dict[str, Any] | None]:
         """Create a sentry event and hint from structlog `event_dict` and sys.exc_info.
 
         :param event_dict: structlog event_dict
@@ -83,7 +85,7 @@ class SentryProcessor:  # pylint: disable=too-few-public-methods
             exc_info = sys.exc_info()
         has_exc_info = exc_info and exc_info != (None, None, None)
 
-        hint: Optional[Dict[str, Any]]
+        hint: dict[str, Any] | None
         if has_exc_info:
             event, hint = event_from_exception(exc_info)
         else:
@@ -103,7 +105,7 @@ class SentryProcessor:  # pylint: disable=too-few-public-methods
 
         return event, hint
 
-    def _log(self, event_dict: structlog.types.EventDict) -> Optional[str]:
+    def _log(self, event_dict: structlog.types.EventDict) -> str | None:
         """Send an event to Sentry and return sentry event id.
 
         :param event_dict: structlog event_dict
@@ -144,7 +146,7 @@ class SentryJsonProcessor(SentryProcessor):  # pylint: disable=too-few-public-me
         level: int = logging.WARNING,
         active: bool = True,
         as_extra: bool = True,
-        tag_keys: Optional[Union[List[str], str]] = None,
+        tag_keys: list[str] | str | None = None,
     ) -> None:
         super().__init__(level=level, active=active, as_extra=as_extra, tag_keys=tag_keys)
         # A set of all encountered structured logger names. If an application uses
@@ -191,7 +193,7 @@ class SentryBreadcrumbJsonProcessor(SentryJsonProcessor):
         level: int = logging.WARNING,
         active: bool = True,
         as_extra: bool = True,
-        tag_keys: Optional[Union[List[str], str]] = None,
+        tag_keys: list[str] | str | None = None,
     ) -> None:
         self.breadcrumb_level = breadcrumb_level
         super().__init__(level=level, active=active, as_extra=as_extra, tag_keys=tag_keys)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,36 +1,36 @@
 """Pytest configuration module"""
 # Silence spurious `config` fixture false-positives
 # pylint: disable=unused-argument
-from typing import Tuple
+from __future__ import annotations
 
 from _pytest.config import Config
 
 
-def pytest_emoji_passed(config: Config) -> Tuple[str, str]:
+def pytest_emoji_passed(config: Config) -> tuple[str, str]:
     """Returns the pytest_emoji symbols for passed tests"""
     return "✅ ", "PASSED ✅ "
 
 
-def pytest_emoji_failed(config: Config) -> Tuple[str, str]:
+def pytest_emoji_failed(config: Config) -> tuple[str, str]:
     """Returns the pytest_emoji symbols for failed tests"""
     return "❌ ", "FAILED ❌ "
 
 
-def pytest_emoji_skipped(config: Config) -> Tuple[str, str]:
+def pytest_emoji_skipped(config: Config) -> tuple[str, str]:
     """Returns the pytest_emoji symbols for skipped tests"""
     return "🙈 ", "SKIPPED 🙈 "
 
 
-def pytest_emoji_error(config: Config) -> Tuple[str, str]:
+def pytest_emoji_error(config: Config) -> tuple[str, str]:
     """Returns the pytest_emoji symbols for tests that unexpectedly encountered errors"""
     return "🚫 ", "ERROR 🚫 "
 
 
-def pytest_emoji_xfailed(config: Config) -> Tuple[str, str]:
+def pytest_emoji_xfailed(config: Config) -> tuple[str, str]:
     """Returns the pytest_emoji symbols for xfailed tests"""
     return "❎️ ", "XFAIL ❎️ "
 
 
-def pytest_emoji_xpassed(config: Config) -> Tuple[str, str]:
+def pytest_emoji_xpassed(config: Config) -> tuple[str, str]:
     """Returns the pytest_emoji symbols for xfail tests that unexpectedly passed"""
     return "⛔️ ", "XPASS ⛔️ "

--- a/tests/docs_src/test_pure_structlog_logging_without_sentry.py
+++ b/tests/docs_src/test_pure_structlog_logging_without_sentry.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import importlib
 import sys
 from types import ModuleType
-from typing import List
 
 import pytest
 from _pytest.capture import CaptureFixture
@@ -17,7 +18,7 @@ from tests.utils import JSONOutputType
 
 
 @pytest.fixture(scope="function")
-def expected_output_truncated() -> List[JSONOutputType]:
+def expected_output_truncated() -> list[JSONOutputType]:
     return [
         {
             "event": "Your log message",
@@ -32,7 +33,7 @@ def expected_output_truncated() -> List[JSONOutputType]:
 
 
 @pytest.fixture(scope="function")
-def actual_output(capsys: CaptureFixture, caplog: LogCaptureFixture, monkeypatch: MonkeyPatch) -> List[JSONOutputType]:
+def actual_output(capsys: CaptureFixture, caplog: LogCaptureFixture, monkeypatch: MonkeyPatch) -> list[JSONOutputType]:
     tests.utils.enable_sentry_integration_mode(monkeypatch)
     reload_module_non_dev_local_env(monkeypatch, pure_structlog_logging_without_sentry)
     tests.utils.redirect_captured_logs_to_stdout(caplog)
@@ -74,8 +75,8 @@ def test_dev_local(capsys: CaptureFixture, caplog: LogCaptureFixture, monkeypatc
 
 # pylint: disable=redefined-outer-name
 def test_pure_structlog_logging_without_sentry(
-    expected_output_truncated: List[JSONOutputType],
-    actual_output: List[JSONOutputType],
+    expected_output_truncated: list[JSONOutputType],
+    actual_output: list[JSONOutputType],
 ) -> None:
     tests.docs_src.validate_output.validate_output(
         expected_output_truncated, actual_output, dynamic_keys_to_copy=["timestamp"]

--- a/tests/docs_src/test_sentry_integration.py
+++ b/tests/docs_src/test_sentry_integration.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import pytest
 from _pytest.capture import CaptureFixture
@@ -11,7 +11,7 @@ JSONOutputType = tests.utils.JSONOutputType
 
 
 @pytest.fixture(scope="function")
-def expected_output_truncated() -> List[JSONOutputType]:
+def expected_output_truncated() -> list[JSONOutputType]:
     return [
         {
             "event": "A dummy error for testing purposes is about to be thrown!\n",
@@ -38,7 +38,7 @@ def expected_output_truncated() -> List[JSONOutputType]:
 
 
 @pytest.fixture(scope="function")
-def actual_output(capsys: CaptureFixture, monkeypatch: MonkeyPatch) -> List[JSONOutputType]:
+def actual_output(capsys: CaptureFixture, monkeypatch: MonkeyPatch) -> list[JSONOutputType]:
     tests.utils.enable_sentry_integration_mode(monkeypatch)
     with pytest.raises(RuntimeError):
         import docs_src.sentry_integration  # pylint: disable=import-outside-toplevel,unused-import
@@ -47,8 +47,8 @@ def actual_output(capsys: CaptureFixture, monkeypatch: MonkeyPatch) -> List[JSON
 
 # pylint: disable=redefined-outer-name
 def test_sentry_integration(
-    expected_output_truncated: List[JSONOutputType],
-    actual_output: List[JSONOutputType],
+    expected_output_truncated: list[JSONOutputType],
+    actual_output: list[JSONOutputType],
 ) -> None:
     tests.docs_src.validate_output.validate_output(
         expected_output_truncated,

--- a/tests/docs_src/validate_output.py
+++ b/tests/docs_src/validate_output.py
@@ -1,12 +1,12 @@
-from typing import List
+from __future__ import annotations
 
 from tests.utils import JSONOutputType
 
 
 def validate_output(
-    expected_output_truncated: List[JSONOutputType],
-    actual_output: List[JSONOutputType],
-    dynamic_keys_to_copy: List[str],
+    expected_output_truncated: list[JSONOutputType],
+    actual_output: list[JSONOutputType],
+    dynamic_keys_to_copy: list[str],
 ) -> None:
     for expected_log_truncated, actual_log in zip(expected_output_truncated, actual_output):
         expected_log = {

--- a/tests/structlog_sentry_logger/test__config.py
+++ b/tests/structlog_sentry_logger/test__config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import enum
 import importlib
@@ -7,7 +9,7 @@ import sys
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Union
 
 import dotenv
 import git
@@ -37,7 +39,7 @@ JSONOutputType = tests.utils.JSONOutputType
 # complicated patching.
 
 
-def serialized_repr(v: Union[Dict, List]) -> JSONOutputType:
+def serialized_repr(v: dict | list) -> JSONOutputType:
     return orjson.loads(
         structlog_sentry_logger._config.serializer(  # pylint: disable=protected-access
             v, option=orjson.OPT_NON_STR_KEYS
@@ -46,7 +48,7 @@ def serialized_repr(v: Union[Dict, List]) -> JSONOutputType:
 
 
 @pytest.fixture(scope="function")
-def random_log_msgs(iters: int = 10) -> List[str]:
+def random_log_msgs(iters: int = 10) -> list[str]:
     return [str(uuid.uuid4()) for _ in range(iters)]
 
 
@@ -55,15 +57,15 @@ def random_log_msgs(iters: int = 10) -> List[str]:
 LogType = Dict[str, Union[uuid.UUID, str]]
 
 
-def test_pytest_caplog_and_structlog_patching_equivalence(capsys: CaptureFixture, random_log_msgs: List[str]) -> None:
-    def get_pytest_captured_logs() -> List[JSONOutputType]:
+def test_pytest_caplog_and_structlog_patching_equivalence(capsys: CaptureFixture, random_log_msgs: list[str]) -> None:
+    def get_pytest_captured_logs() -> list[JSONOutputType]:
         logger = structlog_sentry_logger.get_logger()
         for log_msg in random_log_msgs:
             logger.debug(log_msg)
         return tests.utils.get_validated_json_output(capsys)
 
     # List[Dict[str,Union[uuid.UUID, str]]]
-    def get_structlog_captured_logs() -> List[JSONOutputType]:
+    def get_structlog_captured_logs() -> list[JSONOutputType]:
         # Setup
         structlog_caplog = structlog.testing.LogCapture()
         orig_processors = structlog.get_config()["processors"]
@@ -280,7 +282,7 @@ class TestBasicLogging:  # pylint: disable=too-few-public-methods
         "emoji hat (🎩)": "emoji cat (🐈)",
     }
 
-    test_data: Dict[str, Any] = {
+    test_data: dict[str, Any] = {
         **test_cases,
         "all test cases simultaneously": test_cases,
     }
@@ -319,7 +321,7 @@ class TestBasicLoggingNonStringKeys:  # pylint: disable=too-few-public-methods
         uuid.UUID("7202d115-7ff3-4c81-a7c1-2a1f067b1ece"): "uuid.UUID key",
     }
 
-    test_data: Dict[Any, Union[str, dict]] = {
+    test_data: dict[Any, str | dict] = {
         **test_cases,
         "all test cases simultaneously": test_cases,
     }
@@ -500,7 +502,7 @@ class TestLoggerSchema:
     def test_structlog_logger(
         capsys: CaptureFixture,
         monkeypatch: MonkeyPatch,
-        random_log_msgs: List[str],
+        random_log_msgs: list[str],
         is_sentry_integration_mode_requested: bool,
         is_sentry_integration_installed: bool,
     ) -> None:
@@ -553,7 +555,7 @@ class TestLoggerSchema:
             assert "timestamp" in log
 
     @staticmethod
-    def test_non_structlog_logger(capsys: CaptureFixture, random_log_msgs: List[str]) -> None:
+    def test_non_structlog_logger(capsys: CaptureFixture, random_log_msgs: list[str]) -> None:
         logger = structlog_sentry_logger.get_logger()
         for log_msg in random_log_msgs:
             logger.debug(log_msg)
@@ -656,8 +658,8 @@ class TestLoadingDotenv:
 
 
 class TestBasicPerfLogging:
-    test_data: Dict[str, Any] = TestBasicLogging.test_data
-    cloud_logging_compatibility_mode_env_vars: List[str] = TestCloudLogging.cloud_logging_compatibility_mode_env_vars
+    test_data: dict[str, Any] = TestBasicLogging.test_data
+    cloud_logging_compatibility_mode_env_vars: list[str] = TestCloudLogging.cloud_logging_compatibility_mode_env_vars
 
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, monkeypatch: MonkeyPatch) -> None:

--- a/tests/structlog_sentry_logger/test_startup.py
+++ b/tests/structlog_sentry_logger/test_startup.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 import itertools
 import sys
-from typing import List, Tuple
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from pytest_mock import MockerFixture
 
 
-def powerset(iterable: List[str]) -> List[Tuple[str, ...]]:
+def powerset(iterable: list[str]) -> list[tuple[str, ...]]:
     return list(itertools.chain.from_iterable(itertools.combinations(iterable, x) for x in range(len(iterable) + 1)))
 
 
@@ -29,7 +30,7 @@ test_cases = {str(v): v for v in (powerset(_ENV_VAR_FEATURE_FLAGS))}
 def test_feat_flags(
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
-    feature_flag_combination: List[str],
+    feature_flag_combination: list[str],
 ) -> None:
     # Ensure test isolation by pre-patching sys modules to prevent side effects from
     # library import affecting other tests

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import orjson
 import structlog
@@ -36,7 +38,7 @@ def redirect_captured_logs_to_stdout(caplog: LogCaptureFixture) -> None:
             print(orjson.dumps(record.msg).decode())
 
 
-def get_validated_json_output(capsys: CaptureFixture) -> List[JSONOutputType]:
+def get_validated_json_output(capsys: CaptureFixture) -> list[JSONOutputType]:
     captured = capsys.readouterr()
     assert captured.out
     assert not captured.err
@@ -47,9 +49,9 @@ def get_validated_json_output(capsys: CaptureFixture) -> List[JSONOutputType]:
     return orjson_lib_ver
 
 
-def read_json_logs_from_stdout(capsys: CaptureFixture) -> List[dict]:
+def read_json_logs_from_stdout(capsys: CaptureFixture) -> list[dict]:
     return [orjson.loads(log) for log in parse_logs_from_stdout(capsys)]
 
 
-def parse_logs_from_stdout(capsys: CaptureFixture) -> List[str]:
+def parse_logs_from_stdout(capsys: CaptureFixture) -> list[str]:
     return capsys.readouterr().out.strip().split("\n")


### PR DESCRIPTION
## WHAT

SSIA, i.e., via 

```python
from __future__ import annotations
``` 

See:
- [PEP 563](https://peps.python.org/pep-0563/)

And updating type annotations accordingly. 

## WHY

Primarily to use more modern Python typing syntax while maintaining backwards compatibility.

Note: Benchmarks confirmed to be roughly the same before and after (taking into account variations likely due to machine throttling).
