### PR TITLE
💚 📌  Constrain `mypy` to <1.0 for C-compilation

### DIFF
--- a/.mutmut-cache
+++ b/.mutmut-cache
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:982244270647633d636ab9a401a27284b16cd8a3ad0703ccb5cc04c31f36f00d
+oid sha256:e69989f02be64b7e715cad7000ae5892dcd47b0ac66e74b49eebb9023fe76c4e
 size 143360

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,5 +197,5 @@ max-complexity = 10
 convention = "google"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "mypy>=0.910", "setuptools>=58.1.0", "orjson>=3.6.4"]
+requires = ["poetry-core>=1.0.0", "mypy>=0.910,<1.0.0", "setuptools>=58.1.0", "orjson>=3.6.4"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## WHAT

SSIA, but only for required build dependencies. 

Relates to:
- #813 

## WHY

Fixes, e.g.,
```log
Traceback (most recent call last):
  File "./docs_src/pure_structlog_logging_without_sentry.py", line 3, in <module>
    LOGGER = structlog_sentry_logger.get_logger()
  File "/project/structlog_sentry_logger/_config.py", line 92, in get_logger
AttributeError: attribute 'stdlib_logging_config_already_configured' of 'Config' undefined
Error: Process completed with exit code 1.
```
see: https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/4124874295/jobs/7126891777