### PR TITLE
🐛 Infer git project root with invoking `git`

### DIFF
--- a/.mutmut-cache
+++ b/.mutmut-cache
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e69989f02be64b7e715cad7000ae5892dcd47b0ac66e74b49eebb9023fe76c4e
+oid sha256:521b4fb2773db4fd73712b9b8822e18c5d46f2511349b0ebdf2d416501fd78d7
 size 143360

--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -53,7 +53,11 @@ def get_root_dir() -> pathlib.Path:
 
 def get_git_root() -> pathlib.Path:  # Gratuitous indirection for testing
     git_repo = git.Repo(pathlib.Path.cwd(), search_parent_directories=True)
-    git_root = git_repo.git.rev_parse("--show-toplevel")
+
+    # Note: `working_dir` should never be None, but mypy complains and there may be some
+    # unknown corner case, so falling back to the system root directory for module
+    # namespacing (this might be better merged with the logic in `get_root_dir`).
+    git_root = git_repo.working_dir or pathlib.Path.cwd().resolve().root
     return pathlib.Path(git_root)
 
 

--- a/tests/structlog_sentry_logger/test__config.py
+++ b/tests/structlog_sentry_logger/test__config.py
@@ -224,6 +224,41 @@ def test_read_only_root_dir(mocker: MockerFixture, tmp_path: Path) -> None:
     assert filename_path.relative_to(Path(tempfile.mkdtemp()).parent)
 
 
+def test_mock_read_bad_git_ownership_root_dir(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """Test the case where a git root directory tries to be inferred by a user who is not the owner.
+
+    This returns the same error as if `git.Repo(dir).git.rev_parse("--show-toplevel")` was
+    executed in a git directory not owned by the current user. Ideally we would like to
+    replicate behavior by `chown`-ing `tmp_path` to a different user, but this is not possible
+    with the default user's permissions.
+    """
+
+    def mock_err(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        redacted_command = ["git", "rev-parse", "--show-toplevel"]
+        status = 128
+        stderr_value = (
+            b"fatal: detected dubious ownership in repository at '/src'\n"
+            b"To add an exception for this directory, call:\n\n"
+            b"\tgit config --global --add safe.directory /src"
+        )
+        stdout_value = b""
+        raise git.GitCommandError(redacted_command, status, stderr_value, stdout_value)
+
+    # Initialize and cd into a dummy Git repo
+    git.Repo.init(tmp_path, bare=False)
+    os.chdir(tmp_path)
+
+    # Patch the underlying method which executes git commands. This will make any
+    # git command error out with the "dubious ownership" error
+    monkeypatch.setattr(git.Git, "_call_process", mock_err)
+
+    # Validate a "dubious ownership" error is raised when attempting to infer the
+    # project root directory
+    with pytest.raises(git.GitCommandError):
+        _ = structlog_sentry_logger._config.get_git_root()
+
+
 def test_no_filename_handler(mocker: MockerFixture, monkeypatch: MonkeyPatch) -> None:
     mocker.patch.object(
         structlog_sentry_logger._config,

--- a/tests/structlog_sentry_logger/test__config.py
+++ b/tests/structlog_sentry_logger/test__config.py
@@ -253,10 +253,9 @@ def test_mock_read_bad_git_ownership_root_dir(monkeypatch: MonkeyPatch, tmp_path
     # git command error out with the "dubious ownership" error
     monkeypatch.setattr(git.Git, "_call_process", mock_err)
 
-    # Validate a "dubious ownership" error is raised when attempting to infer the
+    # Validate a "dubious ownership" error is *not* raised when attempting to infer the
     # project root directory
-    with pytest.raises(git.GitCommandError):
-        _ = structlog_sentry_logger._config.get_git_root()
+    assert tmp_path == structlog_sentry_logger._config.get_git_root()
 
 
 def test_no_filename_handler(mocker: MockerFixture, monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
## WHAT

SSIA.

## WHY

To fix an edge case where users did not have the correct permissions for the git repository they were in.
- Resolves #812