### PR TITLE
🚨  Fix security scanning for `CVE-2023-24816`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -210,7 +210,8 @@ commands = poetry build
 skip_install = true
 deps = safety
 commands = safety check --full-report -r {toxinidir}/requirements-all.txt \
-    --ignore=51457 # CVE-2022-42969
+    # CVE-2022-42969
+    --ignore=51457
 
 [testenv:docs]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -211,7 +211,9 @@ skip_install = true
 deps = safety
 commands = safety check --full-report -r {toxinidir}/requirements-all.txt \
     # CVE-2022-42969
-    --ignore=51457
+    --ignore=51457 \
+    # CVE-2023-24816
+    --ignore=53269
 
 [testenv:docs]
 extras =


### PR DESCRIPTION
Must follow this up by dropping Python 3.7 support ([EOL in 2023/06](https://peps.python.org/pep-0537/#and-beyond-schedule:~:text=Security%20fixes%20only%2C%20as%20needed%2C%20until%202023%2D06)):
```shell
❯ poetry add ipython=8.11.0        

Updating dependencies
Resolving dependencies... (0.0s)

The current project's Python requirement (>=3.7,<3.12) is not compatible with some of the required packages Python requirement:
  - ipython requires Python >=3.8, so it will not be satisfied for Python >=3.7,<3.8

Because structlog-sentry-logger depends on ipython (8.11.0) which requires Python >=3.8, version solving failed.

  • Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties
    
    For ipython, a possible solution would be to set the `python` property to ">=3.8,<3.12"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers

```