### PR TITLE
:arrow_up: Bump `jinja2` to 3.1.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -875,13 +875,13 @@ testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jinja2"
-version = "3.1.3"
+version = "3.1.4"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
-    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
+    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
+    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
```
-> Vulnerability found in jinja2 version 3.1.3
   Vulnerability ID: 70612
   Affected spec: >=0
   ADVISORY: In Jinja2, the from_string function is prone to Server
   Side Template Injection (SSTI) where it takes the source parameter as a
   template object, renders it, and then returns it. The attacker can exploit
   it with INJECTION COMMANDS in a URI. NOTE: The maintainer and multiple
   third parties believe that this vulnerability isn't valid because users
   shouldn't use untrusted templates without sandboxing.
   CVE-2019-8341
   For more information about this vulnerability, visit
   https://data.safetycli.com/v/70612/97c
   To ignore this vulnerability, use PyUp vulnerability id 70612 in safety’s
   ignore command-line argument or add the ignore to your safety policy file.


-> Vulnerability found in jinja2 version 3.1.3
   Vulnerability ID: 715[91](https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10775265503/job/29879277340#step:8:92)
   Affected spec: <3.1.4
   ADVISORY: Jinja is an extensible templating engine. The `xmlattr`
   filter in affected versions of Jinja accepts keys containing non-attribute
   characters. XML/HTML attributes cannot contain spaces, `/`, `>`, or `=`,
   as each would then be interpreted as starting a separate attribute. If an
   application accepts keys (as opposed to only values) as user input, and
   renders these in pages that other users see as well, an attacker could use
   this to inject other attributes and perform XSS. The fix for
   CVE-2024-221[95](https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10775265503/job/29879277340#step:8:96) only addressed spaces but not other characters. Accepting
   keys as user input is now explicitly considered an unintended use case of
   the `xmlattr` filter, and code that does so without otherwise validating
   the input should be flagged as insecure, regardless of Jinja version.
   Accepting _values_ as user input continues to be safe.
   CVE-2024-34064
   For more information about this vulnerability, visit
   https://data.safetycli.com/v/71591/[97](https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10775265503/job/29879277340#step:8:98)c
   To ignore this vulnerability, use PyUp vulnerability id 71591 in safety’s
   ignore command-line argument or add the ignore to your safety policy file.
```