### PR TITLE
:lock: Ignore `CVE-2019-8341`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -209,6 +209,8 @@ commands = poetry build
 skip_install = true
 deps = safety
 commands = safety check --full-report -r {toxinidir}/requirements-all.txt \
+    # CVE-2019-8341
+    --ignore=70612 \
     # CVE-2022-42969
     --ignore=51457 \
     # CVE-2023-24816


### PR DESCRIPTION
Temporarily fixes dependency security vulnerability scanning job.
- example job log: https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10764641806/job/29847753472?pr=1403

```
-> Vulnerability found in jinja2 version 3.1.3
   Vulnerability ID: 70612
   Affected spec: >=0
   ADVISORY: In Jinja2, the from_string function is prone to Server
   Side Template Injection (SSTI) where it takes the source parameter as a
   template object, renders it, and then returns it. The attacker can exploit
   it with INJECTION COMMANDS in a URI. NOTE: The maintainer and multiple
   third parties believe that this vulnerability isn't valid because users
   shouldn't use untrusted templates without sandboxing.
   CVE-2019-8341
   For more information about this vulnerability, visit
   https://data.safetycli.com/v/70612/97c
   To ignore this vulnerability, use PyUp vulnerability id 70612 in safety’s
   ignore command-line argument or add the ignore to your safety policy file.
```