### PR TITLE
`[2024-09-10]`rotating_light: Fix `mypy` lint errors for `structlog` and `sentry` type analysis

### DIFF
--- a/structlog_sentry_logger/structlog_sentry.py
+++ b/structlog_sentry_logger/structlog_sentry.py
@@ -15,6 +15,7 @@ import logging
 import sys
 from typing import Any, Iterable
 
+import sentry_sdk.types
 import structlog
 from sentry_sdk import add_breadcrumb, capture_event
 from sentry_sdk.integrations.logging import ignore_logger as logging_int_ignore_logger
@@ -75,7 +76,9 @@ class SentryProcessor:  # pylint: disable=too-few-public-methods
 
         return logger_name
 
-    def _get_event_and_hint(self, event_dict: structlog.types.EventDict) -> tuple[dict, dict[str, Any] | None]:
+    def _get_event_and_hint(
+        self, event_dict: structlog.types.EventDict
+    ) -> tuple[sentry_sdk.types.Event, dict[str, Any] | None]:
         """Create a sentry event and hint from structlog `event_dict` and sys.exc_info.
 
         :param event_dict: structlog event_dict
@@ -92,8 +95,8 @@ class SentryProcessor:  # pylint: disable=too-few-public-methods
         else:
             event, hint = {}, None
 
-        event["message"] = event_dict.get("event")
-        event["level"] = event_dict.get("level")
+        event["message"] = event_dict.get("event")  # type: ignore[typeddict-item]
+        event["level"] = event_dict.get("level")  # type: ignore[typeddict-item]
         if "logger" in event_dict:
             event["logger"] = event_dict["logger"]
 


### PR DESCRIPTION
```shell
mypy.................................................................................Failed
- hook id: mypy
- duration: 4.76s
- exit code: 1

structlog_sentry_logger/_config.py:27: note: In module imported here,
structlog_sentry_logger/__init__.py:4: note: ... from here:
structlog_sentry_logger/structlog_sentry.py: note: In member "_get_event_and_hint" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:95:28: error: Value of "message"
has incompatible type "Any | None"; expected "str"  [typeddict-item]
            event["message"] = event_dict.get("event")
                               ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:96:26: error: Value of "level" has
incompatible type "Any | None"; expected
"Literal['fatal', 'critical', 'error', 'warning', 'info', 'debug']" 
[typeddict-item]
            event["level"] = event_dict.get("level")
                             ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:107:16: error: Incompatible return
value type (got "tuple[Event, dict[str, Any] | None]", expected
"tuple[dict[Any, Any], dict[str, Any] | None]")  [return-value]
            return event, hint
                   ^~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py: note: In member "_log" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:115:30: error: Argument 1 to
"capture_event" has incompatible type "dict[Any, Any]"; expected "Event" 
[arg-type]
            return capture_event(event, hint=hint)
                                 ^~~~~
Found 4 errors in 1 file (checked 4 source files)
structlog_sentry_logger/_config.py:27: note: In module imported here,
structlog_sentry_logger/__init__.py:4: note: ... from here,
docs_src/pure_structlog_logging_without_sentry.py:1: note: ... from here:
structlog_sentry_logger/structlog_sentry.py: note: In member "_get_event_and_hint" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:95:28: error: Value of "message"
has incompatible type "Any | None"; expected "str"  [typeddict-item]
            event["message"] = event_dict.get("event")
                               ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:96:26: error: Value of "level" has
incompatible type "Any | None"; expected
"Literal['fatal', 'critical', 'error', 'warning', 'info', 'debug']" 
[typeddict-item]
            event["level"] = event_dict.get("level")
                             ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:107:16: error: Incompatible return
value type (got "tuple[Event, dict[str, Any] | None]", expected
"tuple[dict[Any, Any], dict[str, Any] | None]")  [return-value]
            return event, hint
                   ^~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py: note: In member "_log" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:115:30: error: Argument 1 to
"capture_event" has incompatible type "dict[Any, Any]"; expected "Event" 
[arg-type]
            return capture_event(event, hint=hint)
                                 ^~~~~
Found 4 errors in 1 file (checked 4 source files)
structlog_sentry_logger/_config.py:27: note: In module imported here,
structlog_sentry_logger/__init__.py:4: note: ... from here,
tests/structlog_sentry_logger/test__config.py:24: note: ... from here:
structlog_sentry_logger/structlog_sentry.py: note: In member "_get_event_and_hint" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:95:28: error: Value of "message"
has incompatible type "Any | None"; expected "str"  [typeddict-item]
            event["message"] = event_dict.get("event")
                               ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:96:26: error: Value of "level" has
incompatible type "Any | None"; expected
"Literal['fatal', 'critical', 'error', 'warning', 'info', 'debug']" 
[typeddict-item]
            event["level"] = event_dict.get("level")
                             ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:107:16: error: Incompatible return
value type (got "tuple[Event, dict[str, Any] | None]", expected
"tuple[dict[Any, Any], dict[str, Any] | None]")  [return-value]
            return event, hint
                   ^~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py: note: In member "_log" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:115:30: error: Argument 1 to
"capture_event" has incompatible type "dict[Any, Any]"; expected "Event" 
[arg-type]
            return capture_event(event, hint=hint)
                                 ^~~~~
Found 4 errors in 1 file (checked 4 source files)
structlog_sentry_logger/structlog_sentry.py: note: In member "_get_event_and_hint" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:95:28: error: Value of "message"
has incompatible type "Any | None"; expected "str"  [typeddict-item]
            event["message"] = event_dict.get("event")
                               ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:96:26: error: Value of "level" has
incompatible type "Any | None"; expected
"Literal['fatal', 'critical', 'error', 'warning', 'info', 'debug']" 
[typeddict-item]
            event["level"] = event_dict.get("level")
                             ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:107:16: error: Incompatible return
value type (got "tuple[Event, dict[str, Any] | None]", expected
"tuple[dict[Any, Any], dict[str, Any] | None]")  [return-value]
            return event, hint
                   ^~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py: note: In member "_log" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:115:30: error: Argument 1 to
"capture_event" has incompatible type "dict[Any, Any]"; expected "Event" 
[arg-type]
            return capture_event(event, hint=hint)
                                 ^~~~~
Found 4 errors in 1 file (checked 4 source files)
structlog_sentry_logger/_config.py:27: note: In module imported here:
structlog_sentry_logger/structlog_sentry.py: note: In member "_get_event_and_hint" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:95:28: error: Value of "message"
has incompatible type "Any | None"; expected "str"  [typeddict-item]
            event["message"] = event_dict.get("event")
                               ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:96:26: error: Value of "level" has
incompatible type "Any | None"; expected
"Literal['fatal', 'critical', 'error', 'warning', 'info', 'debug']" 
[typeddict-item]
            event["level"] = event_dict.get("level")
                             ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:107:16: error: Incompatible return
value type (got "tuple[Event, dict[str, Any] | None]", expected
"tuple[dict[Any, Any], dict[str, Any] | None]")  [return-value]
            return event, hint
                   ^~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py: note: In member "_log" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:115:30: error: Argument 1 to
"capture_event" has incompatible type "dict[Any, Any]"; expected "Event" 
[arg-type]
            return capture_event(event, hint=hint)
                                 ^~~~~
Found 4 errors in 1 file (checked 4 source files)
structlog_sentry_logger/_config.py:27: note: In module imported here,
structlog_sentry_logger/__init__.py:4: note: ... from here,
tests/structlog_sentry_logger/child_module_2.py:1: note: ... from here:
structlog_sentry_logger/structlog_sentry.py: note: In member "_get_event_and_hint" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:95:28: error: Value of "message"
has incompatible type "Any | None"; expected "str"  [typeddict-item]
            event["message"] = event_dict.get("event")
                               ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:96:26: error: Value of "level" has
incompatible type "Any | None"; expected
"Literal['fatal', 'critical', 'error', 'warning', 'info', 'debug']" 
[typeddict-item]
            event["level"] = event_dict.get("level")
                             ^~~~~~~~~~~~~~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py:107:16: error: Incompatible return
value type (got "tuple[Event, dict[str, Any] | None]", expected
"tuple[dict[Any, Any], dict[str, Any] | None]")  [return-value]
            return event, hint
                   ^~~~~~~~~~~
structlog_sentry_logger/structlog_sentry.py: note: In member "_log" of class "SentryProcessor":
structlog_sentry_logger/structlog_sentry.py:115:30: error: Argument 1 to
"capture_event" has incompatible type "dict[Any, Any]"; expected "Event" 
[arg-type]
            return capture_event(event, hint=hint)
                                 ^~~~~
Found 4 errors in 1 file (checked 3 source files)
```