### PR TITLE
:green_heart: Remove Python 3.8 tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     name: Python ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fixes:
```
Collecting pyyaml==6.0 (from -r requirements-dev.txt (line 99))
  Downloading PyYAML-6.0.tar.gz (124 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [48 lines of output]
      running egg_info
      writing lib/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/.tox/py38/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/.tox/py38/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/.tox/py38/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 288, in <module>
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 184, in setup
          return run_commands(dist)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 200, in run_commands
          dist.run_commands()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 954, in run_commands
          self.run_command(cmd)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 950, in run_command
          super().run_command(command)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 973, in run_command
          cmd_obj.run()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 311, in run
          self.find_sources()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 319, in find_sources
          mm.run()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 540, in run
          self.add_defaults()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 578, in add_defaults
          sdist.add_defaults(self)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/command/sdist.py", line 108, in add_defaults
          super().add_defaults()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/sdist.py", line 250, in add_defaults
          self._add_defaults_ext()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/sdist.py", line 335, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "<string>", line 204, in get_source_files
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-8q8cxho7/overlay/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [48 lines of output]
      running egg_info
      writing lib/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/.tox/c_library/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/.tox/c_library/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/.tox/c_library/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 288, in <module>
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 184, in setup
          return run_commands(dist)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 200, in run_commands
          dist.run_commands()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 954, in run_commands
          self.run_command(cmd)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 950, in run_command
          super().run_command(command)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 973, in run_command
          cmd_obj.run()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 311, in run
          self.find_sources()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 319, in find_sources
          mm.run()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 540, in run
          self.add_defaults()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 578, in add_defaults
          sdist.add_defaults(self)
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/command/sdist.py", line 108, in add_defaults
          super().add_defaults()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/sdist.py", line 250, in add_defaults
          self._add_defaults_ext()
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/sdist.py", line 335, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "<string>", line 204, in get_source_files
        File "/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pip-build-env-2wyddx_4/overlay/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
c_library: install_deps> python -I -m pip install -r requirements-dev.txt
c_library: exit 1 (7.95 seconds) /Users/runner/work/structlog-sentry-logger/structlog-sentry-logger> python -I -m pip install -r requirements-dev.txt pid=2144
py38: install_deps> python -I -m pip install -r requirements-dev.txt
py38: exit 1 (7.99 seconds) /Users/runner/work/structlog-sentry-logger/structlog-sentry-logger> python -I -m pip install -r requirements-dev.txt pid=2143
c_library: FAIL ✖ in 8.34 seconds
  py38: FAIL code 1 (8.34 seconds)
  c_library: FAIL code 1 (8.34 seconds)
  evaluation failed :( (8.38 seconds)
make: *** [test] Error 255
Warning: Attempt 1 failed. Reason: Child_process exited with error code 2
```