### PR TITLE
:green_heart: Fix mutation testing cache uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,3 +295,4 @@ jobs:
         with:
           name: mutmut-cache
           path: ./.mutmut-cache
+          include-hidden-files: true

--- a/.mutmut-cache
+++ b/.mutmut-cache
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0f44e55556680af362dcf4eae15c4e8ed8cfa02ae03382a838ede3be317565c
+oid sha256:8aaeefef3b728ea5168e64b502715858c0507c8a10172f029bf1c213da94df0f
 size 143360


### PR DESCRIPTION
> [!NOTE]
> 
> Relates to:
> - https://github.com/TeoZosa/structlog-sentry-logger/pull/1412

Due to breaking change from upload-artifacts GH action excluding hidden files by default.

See:
 - https://github.com/actions/upload-artifact/issues/602