### PR TITLE
:ambulance: Initialize Config object with explicit defaults

### DIFF
--- a/structlog_sentry_logger/_config.py
+++ b/structlog_sentry_logger/_config.py
@@ -29,7 +29,7 @@ except ImportError:
     SentryBreadcrumbJsonProcessor = None  # type: ignore
 
 
-@dataclasses.dataclass(init=False)
+@dataclasses.dataclass
 class Config:
     use_orjson: bool = True
     orjson_configs: int = orjson.OPT_NON_STR_KEYS
@@ -68,7 +68,12 @@ _SENTRY_LOG_LEVEL = logging.getLevelName(os.environ.get("STRUCTLOG_SENTRY_LOGGER
 
 ROOT_DIR = get_root_dir()
 _TIMESTAMPER = structlog.processors.TimeStamper(fmt="iso", utc=True)
-_CONFIGS = Config()
+_CONFIGS = Config(
+    use_orjson=True,
+    orjson_configs=orjson.OPT_NON_STR_KEYS,
+    stdlib_logging_config_already_configured=False,
+    stdlib_logging_sort_keys=False,
+)
 
 
 def _toggle_json_library(use_orjson: bool = True) -> None:


### PR DESCRIPTION
When compiling the library to C via `mypyc`, the class-defaults are not used and must be explicitly passed during initialization.

([Job log](https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10841367492/job/30086454717))
```shell
Run echo "Default output (JSON)"
  echo "Default output (JSON)"
  python ./docs_src/pure_structlog_logging_without_sentry.py
  echo "Cloud Logging compatibility mode (JSON)"
  export STRUCTLOG_SENTRY_LOGGER_CLOUD_LOGGING_COMPATIBILITY_MODE_ON=
  python ./docs_src/pure_structlog_logging_without_sentry.py
  echo "Local development mode output (formatted) \
    (with Cloud Logging compatibility mode still activated)"
  export STRUCTLOG_SENTRY_LOGGER_LOCAL_DEVELOPMENT_LOGGING_MODE_ON=
  python ./docs_src/pure_structlog_logging_without_sentry.py
  shell: /bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    pythonLocation: /Users/runner/hostedtoolcache/Python/3.[1](https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10841367492/job/30086454717#step:5:1)1.9/arm64
    PKG_CONFIG_PATH: /Users/runner/hostedtoolcache/Python/3.11.9/arm64/lib/pkgconfig
    Python_ROOT_DIR: /Users/runner/hostedtoolcache/Python/3.11.9/arm64
    Python[2](https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10841367492/job/30086454717#step:5:2)_ROOT_DIR: /Users/runner/hostedtoolcache/Python/[3](https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10841367492/job/30086454717#step:5:3).11.9/arm64
    Python3_ROOT_DIR: /Users/runner/hostedtoolcache/Python/3.11.9/arm6[4](https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10841367492/job/30086454717#step:5:4)
Default output (JSON)
Traceback (most recent call last):
  File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/./docs_src/pure_structlog_logging_without_sentry.py", line 1, in <module>
    import structlog_sentry_logger
  File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/structlog_sentry_logger/__init__.py", line 4, in <module>
    from structlog_sentry_logger._config import (
  File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/structlog_sentry_logger/_config.py", line 437, in <module>
    __LOGGER = __get_meta_logger()
  File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/structlog_sentry_logger/_config.py", line 430, in __get_meta_logger
    set_optimized_structlog_config()
  File "/Users/runner/work/structlog-sentry-logger/structlog-sentry-logger/structlog_sentry_logger/_config.py", line 3[5](https://github.com/TeoZosa/structlog-sentry-logger/actions/runs/10841367492/job/30086454717#step:5:5)0, in set_optimized_structlog_config
    option=_CONFIGS.orjson_configs,
AttributeError: attribute 'orjson_configs' of 'Config' undefined
```